### PR TITLE
fix: change outlinks to include only links

### DIFF
--- a/content/02-datamodeling/01-intro-dont-panic.mdx
+++ b/content/02-datamodeling/01-intro-dont-panic.mdx
@@ -6,12 +6,19 @@ metaDescription: "Intro (Don't Panic)"
  ## Introduction
 
 If you're reading this, you are more than likely being pressed into service as a database architect. This can befall you any number of ways: you might be a developer or analyst tasked with your first (or fortieth) improvement or patch job on an existing data model, or you could be staring down the blank canvas of an empty database like a rookie matador. Two things are certain: first, information needs to be stored and retrieved, as efficiently and conveniently as possible; and second, you're the one who needs to make it work. This guide will help you get to grips with modeling information and producing durable and maintainable database schema designs. We'll concentrate on relational databases for the most part, so you should come into this with a basic grasp of storing and retrieving data with SQL. Ideally, you'll have a database of your own to experiment in; examples will be given for PostgreSQL, a free and open-source database management system.
+<PrismaOutlinks inner="true"/>
 
 So: data modeling. Like everything else in computing, it's math once you get right down to it. However, its day-to-day practice is almost entirely abstracted to the level of structuring and managing information as it flows through various systems. We'll touch on some of the mathy fundamentals of sets and predicates later on, but the database designer must solve problems of legibility and maintainability as much as of raw mathematical efficiency. As Heinz Klein and Kalle Lyytinen put it thirty years ago, <footnote> <note> _Towards a New Understanding of Data Modeling_ <br/> in <a href="https://www.researchgate.net/publication/242530010_Software_Development_and_Reality_Construction">Software Development and Reality Construction</a> </note> <text> "the appropriate metaphors for data modelling are not fact gathering and modelling, but negotiation and lawmaking" </text> </footnote>.
 
 
 This is intended eventually to be a complete crash course in (relational, although not ignoring others) designing data models. For now, we're publishing parts as they're written, and concentrating first on situating databases and data modeling problems in an organization and systems design context, as well as covering some of the less-prominent areas of database functionality.
+<PrismaOutlinks>
 
+- [Documentation - Advanced usage of generated types ](http://melconway.com/Home/Conways_Law.html)
+- [Documentation - Installing the Prisma CLI](http://melconway.com/Home/Conways_Law.html)
+- [Blog - Building a Modern Backend with TypeScript, PostgreSQL and Prisma: REST API, Validation, and Testing](http://melconway.com/Home/Conways_Law.html)
+
+</PrismaOutlinks>
 <AuthorInfo name="Dian Fay" image="/content/modeling/dmfay.jpg">
 
 Dian didn’t exactly plan to drop out of college to specialize in SQL and backend development, but that’s how it happened. Fifteen years later, she’s designed databases supporting everything from industrial logistics and traceability systems to million-plus user social media games. She is the current maintainer of <a href="https://massivejs.org">MassiveJS</a>, an open source data mapper for Node.js focused on using PostgreSQL to the fullest.

--- a/content/02-datamodeling/01-intro-dont-panic.mdx
+++ b/content/02-datamodeling/01-intro-dont-panic.mdx
@@ -6,19 +6,12 @@ metaDescription: "Intro (Don't Panic)"
  ## Introduction
 
 If you're reading this, you are more than likely being pressed into service as a database architect. This can befall you any number of ways: you might be a developer or analyst tasked with your first (or fortieth) improvement or patch job on an existing data model, or you could be staring down the blank canvas of an empty database like a rookie matador. Two things are certain: first, information needs to be stored and retrieved, as efficiently and conveniently as possible; and second, you're the one who needs to make it work. This guide will help you get to grips with modeling information and producing durable and maintainable database schema designs. We'll concentrate on relational databases for the most part, so you should come into this with a basic grasp of storing and retrieving data with SQL. Ideally, you'll have a database of your own to experiment in; examples will be given for PostgreSQL, a free and open-source database management system.
-<PrismaOutlinks inner="true"/>
 
 So: data modeling. Like everything else in computing, it's math once you get right down to it. However, its day-to-day practice is almost entirely abstracted to the level of structuring and managing information as it flows through various systems. We'll touch on some of the mathy fundamentals of sets and predicates later on, but the database designer must solve problems of legibility and maintainability as much as of raw mathematical efficiency. As Heinz Klein and Kalle Lyytinen put it thirty years ago, <footnote> <note> _Towards a New Understanding of Data Modeling_ <br/> in <a href="https://www.researchgate.net/publication/242530010_Software_Development_and_Reality_Construction">Software Development and Reality Construction</a> </note> <text> "the appropriate metaphors for data modelling are not fact gathering and modelling, but negotiation and lawmaking" </text> </footnote>.
 
 
 This is intended eventually to be a complete crash course in (relational, although not ignoring others) designing data models. For now, we're publishing parts as they're written, and concentrating first on situating databases and data modeling problems in an organization and systems design context, as well as covering some of the less-prominent areas of database functionality.
-<PrismaOutlinks>
 
-- [Documentation - Advanced usage of generated types ](http://melconway.com/Home/Conways_Law.html)
-- [Documentation - Installing the Prisma CLI](http://melconway.com/Home/Conways_Law.html)
-- [Blog - Building a Modern Backend with TypeScript, PostgreSQL and Prisma: REST API, Validation, and Testing](http://melconway.com/Home/Conways_Law.html)
-
-</PrismaOutlinks>
 <AuthorInfo name="Dian Fay" image="/content/modeling/dmfay.jpg">
 
 Dian didn’t exactly plan to drop out of college to specialize in SQL and backend development, but that’s how it happened. Fifteen years later, she’s designed databases supporting everything from industrial logistics and traceability systems to million-plus user social media games. She is the current maintainer of <a href="https://massivejs.org">MassiveJS</a>, an open source data mapper for Node.js focused on using PostgreSQL to the fullest.

--- a/src/components/customMdx/prismaOutlinks.tsx
+++ b/src/components/customMdx/prismaOutlinks.tsx
@@ -5,40 +5,24 @@ import withProps from 'styled-components-ts'
 import ListDot from '../../images/blue-list-dot.png'
 import PrismaLogo from '../../icons/PrismaLogo'
 
-interface AuthorProps {
-  name?: string
-  image?: string
+interface OutlinkProps {
+  inner?: boolean
 }
 
-type AuthorInfoProps = React.ReactNode & AuthorProps
+type PrismaOutlinkProps = React.ReactNode & OutlinkProps
 
-const PrismaOutlinks = ({ children, inner }: AuthorInfoProps) => {
-  let withlogo = children
-  let remainingChildren
-  if (Array.isArray(children)) {
-    withlogo =
-      children &&
-      Array.isArray(children) &&
-      children.filter((child: any) => child.props && child.props.mdxType === 'withlogo')
-    remainingChildren =
-      children &&
-      Array.isArray(children) &&
-      children.filter(
-        (child: any) =>
-          !child.props ||
-          !child.props.mdxType ||
-          (child.props && child.props.mdxType !== 'withlogo')
-      )
-  }
-
+const PrismaOutlinks = ({ children, inner }: PrismaOutlinkProps) => {
   return (
     <PrismaOutlinksWrapper inner={inner}>
-      {remainingChildren}
+      {!inner && 'RELATED ON PRISMA.IO'}
+
+      {children}
       <LogoWrapper>
         <span className="icon">
           <PrismaLogo color="#63B3ED" />
         </span>
-        {withlogo}
+        Prisma is an open-source database toolkit for Typescript and Node.js that aims to make app
+        developers more productive and confident when working with databases.
       </LogoWrapper>
     </PrismaOutlinksWrapper>
   )


### PR DESCRIPTION
Usage:
```
<PrismaOutlinks>

- [Documentation - Advanced usage of generated types ](http://melconway.com/Home/Conways_Law.html)
- [Documentation - Installing the Prisma CLI](http://melconway.com/Home/Conways_Law.html)
- [Blog - Building a Modern Backend with TypeScript, PostgreSQL and Prisma: REST API, Validation, and Testing](http://melconway.com/Home/Conways_Law.html)
</PrismaOutlinks>
```

If to be used in inner sections -

```
<PrismaOutlinks inner="true"/>

```