### PR TITLE
modeling: tweak related outlinks in Functional Units

### DIFF
--- a/content/02-datamodeling/08-functional-units.mdx
+++ b/content/02-datamodeling/08-functional-units.mdx
@@ -10,6 +10,12 @@ There are two schools of thought about performing computations in your database:
 
 But databases are, by definition, very good at processing and manipulating information, and most of them make that same control and power available to their users (SQLite and MS Access to a lesser degree). External data processing programs start on the back foot having to pull information out of the database, often across a network, before they can do anything. And where database programs can take full advantage of native set operations, indexing, temporary tables, and other fruits of half a century of database evolution, external programs of any complexity tend to involve some level of wheel-reinvention. So why not put the database to work?
 
+<PrismaOutlinks>
+
+Find out [how to use functions with Prisma](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#using-functions) in the Prisma documentation.
+
+</PrismaOutlinks>
+
 ## Here's why you might *not* want to program your database!
 
 - Database functionality has a tendency to become invisible -- triggers especially. This weakness scales approximately with the size of teams and/or applications interacting with the database, as fewer people remember or are aware of the in-database programming. Documentation helps, but only so much.
@@ -39,13 +45,6 @@ More specifically, MySQL also disallows recursion and some additional SQL statem
 
 So, which to use when? Functions are best suited to logic which applies record by record as data are stored and retrieved. More complex workflows which are invoked by themselves and move data around internally are better as procedures.
 </details>
-
-<PrismaOutlinks>
-
-Find out [how to use functions with Prisma](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#using-functions) in the Prisma documentation.
-
-</PrismaOutlinks>
-
 
 ## Defaults and Generation
 
@@ -95,7 +94,7 @@ CREATE TABLE lots (
 
 <PrismaOutlinks>
 
-If you're using Prisma, our documentation covers the equivalent method of [defining default values for your fields](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#defining-a-default-value).
+If you're using Prisma, our documentation covers the equivalent method of [defining default values for your fields](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema/data-model#defining-a-default-value). Prisma Client also supports [aggregation](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/aggregations), which allows you to perform count, average, and similar operations on data without separate storage.
 
 </PrismaOutlinks>
 
@@ -120,12 +119,6 @@ ALTER TABLE lots
   ALTER COLUMN lot_number SET DEFAULT next_lot_number();
 
 ```
-
-<PrismaOutlinks>
-
-Prisma Client supports [aggregation](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/aggregations), which allows you to perform count, average, etc. on data so that you don't have to store that in a separate column.
-
-</PrismaOutlinks>
 
 ## Workflows
 
@@ -188,7 +181,7 @@ The trigger-action-trigger-action call stack can become arbitrarily long, althou
 
 <PrismaOutlinks>
 
-In Prisma Client, you can achieve similar results using [middleware](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/middleware).  Middleware allows you to perform an action before and after every query (e.g. perform a soft delete).
+In Prisma Client, you can achieve similar results with TypeScript at the client level instead of SQL by using [middleware](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/middleware).  Middleware allows you to perform an action before and after every query (e.g., turn a `delete` query into a "soft" delete which toggles a record's visibility instead).
 
 </PrismaOutlinks>
 


### PR DESCRIPTION
The outlinks in this chapter read a little noisy to me, and I thought a couple could be placed for better impact -- "how to use functions with Prisma" by the intro, and aggregations included with default values since both relate to the same section of the content.