### PR TITLE
feat: sidenote comp

### DIFF
--- a/src/components/customMdx/index.tsx
+++ b/src/components/customMdx/index.tsx
@@ -12,6 +12,7 @@ import DocLink from './docLink'
 import Subsections from './subSections'
 import AuthorInfo from './authorInfo'
 import Footnote from './footnote'
+import Sidenote from './sideNote'
 import PrismaOutlinks from './prismaOutlinks'
 import { withPrefix } from 'gatsby'
 
@@ -34,6 +35,7 @@ export default {
   PrismaOutlinks,
   DocLink,
   footnote: Footnote,
+  Sidenote,
   img: ({ src, ...props }: any) => {
     return (
       <a href={withPrefix(src)} target="_blank">

--- a/src/components/customMdx/sideNote.tsx
+++ b/src/components/customMdx/sideNote.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import styled from 'styled-components'
+
+interface SidenoteProps {
+  title?: string
+}
+
+type SidenoteInfoProps = React.ReactNode & SidenoteProps
+
+const Sidenote = ({ children, ...props }: SidenoteInfoProps) => {
+  return (
+    <SidenoteWrapper>
+        <h3>{props.title}</h3>
+        {children}
+    </SidenoteWrapper>
+  )
+}
+
+export default Sidenote
+
+const SidenoteWrapper = styled.div`
+  background: #f7fafc;
+  padding: 0px 32px 20px;
+  line-height: 22px;
+  color: #4a5568;
+
+  h3 {
+    font-size: 18px;
+    border: 0;
+    margin-top: 0;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+  }
+`


### PR DESCRIPTION
Usage:

```
<Sidenote title="Horseradish">

Pea horseradish azuki bean lettuce avocado asparagus okra. Kohlrabi radish okra azuki bean corn fava bean mustard tigernut jï¿½cama green bean celtuce [collard](collard) greens avocado quandong fennel gumbo black-eyed pea. Grape silver beet watercress potato tigernut corn groundnut. Chickweed okra pea winter purslane coriander yarrow sweet pepper radish garlic brussels sprout groundnut summer purslane earthnut pea tomato spring onion azuki bean gourd.
</Sidenote>
```