### PR TITLE
Remove social image from bottleneck article

### DIFF
--- a/content/09-managing-databases/02-how-to-spot-bottlenecks-in-performance.mdx
+++ b/content/09-managing-databases/02-how-to-spot-bottlenecks-in-performance.mdx
@@ -2,7 +2,6 @@
 title: 'How to Spot Bottlenecks in Performance'
 metaTitle: 'How to Spot Bottlenecks in Performance'
 metaDescription: 'The culprit for many application performance issues can be traced back to the database. In this article, we cover some of the most common performance bottlenecks that you might run into and what to do about them'
-metaImage: '/social/performance-bottlenecks.png'
 ---
 
 ## Introduction


### PR DESCRIPTION
As per discussion here:
https://prisma-company.slack.com/archives/G01DDETGRFB/p1618996431045000?thread_ts=1618996245.041900&cid=G01DDETGRFB