### PR TITLE
docs: fix wrong BIGINT signed range

### DIFF
--- a/content/05-mysql/07-introduction-to-data-types.mdx
+++ b/content/05-mysql/07-introduction-to-data-types.mdx
@@ -77,7 +77,7 @@ The basic list of integer types includes the following:
 | `SMALLINT`   | 2 bytes | -32768 to 32767           | 0 to 65535                |
 | `MEDIUMINT`  | 3 bytes | -8388608 to 8388607       | 0 to 16777215             |
 | `INT`        | 4 bytes | -2147483648 to 2147483647 | 0 to 4294967295           |
-| `BIGINT`     | 8 bytes | -2^63 to -2^63-1          | 0 to 2^64-1               |
+| `BIGINT`     | 8 bytes | -2^63 to 2^63-1           | 0 to 2^64-1               |
 
 The types above are limited by their valid range.  Any value outside of the range will result in an error.
 


### PR DESCRIPTION
Why negative range only on `BIGINT`?
It should be `2^63-1`

REF: https://dev.mysql.com/doc/refman/8.0/en/integer-types.html and the mathematical sense