### PR TITLE
update: algolia path url to avoid conflicts in universal search

### DIFF
--- a/plugins/gatsby-algolia-indexer/gatsby-config.js
+++ b/plugins/gatsby-algolia-indexer/gatsby-config.js
@@ -77,7 +77,7 @@ const handleRawBody = (node) => {
       apiReference: isApiTerm(item.text) ? getApiVal(item.text) : null,
       heading: item.heading ? removeInlineCode(item.heading) : null,
       content: item.text.includes('\n') ? item.text.split(' ').slice(0, 20).join(' ') : item.text,
-      path: `${rest.modSlug.replace(/\d{2,}-/g, '')}${getTitlePath(item)}`,
+      dataguidePath: `${rest.modSlug.replace(/\d{2,}-/g, '')}${getTitlePath(item)}`,
     }
     return record
   })

--- a/src/components/search/hitComps.tsx
+++ b/src/components/search/hitComps.tsx
@@ -55,7 +55,7 @@ const HitComp = styled.div`
 const DocHit = ({ hit, selected }: any) =>
   hit._distinctSeqID == 0 ? (
     <HitComp style={{ background: selected ? '#F7FAFC' : 'white' }}>
-      <Link style={{ boxShadow: `none`, textDecoration: 'none' }} to={hit.path}>
+      <Link style={{ boxShadow: `none`, textDecoration: 'none' }} to={hit.dataguidePath}>
         <ParentTitle slug={hit.slug} nonLink={true} />
         <h3>
           <Snippet hit={hit} attribute="title" tagName="mark" /> /{' '}


### PR DESCRIPTION
Context: 

Both docs and dataguide has the same prop called 'path' which conflicts while being used in Universal text search in /support page and causes SEO 404 errors. So it would be useful to change the prop name of the dataguide from 'path' to 'dataguidePath' to avoid such conflicts.