### PR TITLE
chore: remove all mentions of Data Proxy

### DIFF
--- a/content/09-database-tools/03-connection-pooling.mdx
+++ b/content/09-database-tools/03-connection-pooling.mdx
@@ -15,7 +15,7 @@ In this guide, we'll talk about what connection pooling is, what specific condit
 
 <PrismaOutlinks>
 
-Connection pooling is one of the core features offered by [Prisma's Data Proxy](https://www.prisma.io/docs/data-platform/data-proxy) on the [Prisma Data Platform](https://cloud.prisma.io/).  If you are using Prisma to work with your database, start a free project to easily manage your connections and browse your data.
+Connection pooling is one of the core features offered by [Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) on the [Prisma Data Platform](https://console.prisma.io/).  If you are using Prisma to work with your database, start a free project to easily manage your connections and browse your data.
 
 </PrismaOutlinks>
 
@@ -118,6 +118,6 @@ Database connection limits can quickly cause problems as your application scales
 
 <PrismaOutlinks>
 
-Connection pooling is one of the core features offered by [Prisma's Data Proxy](https://www.prisma.io/docs/data-platform/data-proxy) on the [Prisma Data Platform](https://cloud.prisma.io/).  If you are using Prisma to work with your database, start a free project to easily manage your connections and browse your data.
+Connection pooling is one of the core features offered by [Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) on the [Prisma Data Platform](https://console.prisma.io/).  If you are using Prisma to work with your database, start a free project to easily manage your connections and browse your data.
 
 </PrismaOutlinks>

--- a/content/11-serverless/02-serverless-comparison.mdx
+++ b/content/11-serverless/02-serverless-comparison.mdx
@@ -60,7 +60,7 @@ We'll also briefly cover some serverless computing adjacent technologies like se
 At the end, we'll introduce a few newer tools and services that you might want to keep an eye out for if you are building serverless applications. While they may not be ready for production at this time, they may be able to provide value soon:
 
 - Deno Deploy
-- Prisma Data Proxy
+- Prisma Accelerate
 
 With those categories in mind, we can start to look at the available services.
 
@@ -606,13 +606,11 @@ Finally, we'll introduce a few tools and services that you might want to keep in
 
 Deno Deploy hopes to provide you with a unified developing experience by using the same technology as the Deno CLI. Deno Deploy is currently in beta, so it is worth taking a look at its current progress and checking back in often.
 
-### Prisma Data Proxy
+### Prisma Accelerate
 
-[Prisma Data Proxy](https://www.prisma.io/docs/data-platform#prisma-data-proxy) is a new tool designed to make connecting to databases simpler in a serverless context. Because the instances used by serverless providers to execute functions are, by nature, ephemeral, it is easy to exhaust the connection pool to any backing databases if too many function instances are active at once.
+[Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) is a tool designed to make connecting to databases simpler in a serverless context. Because the instances used by serverless providers to execute functions are, by nature, ephemeral, it is easy to exhaust the connection pool to any backing databases if too many function instances are active at once.
 
-Prisma Data Proxy provides a solution for this problem by acting as an intermediary to a database. Serverless instances can instead connect to the Data Proxy which manages the connection pooling automatically to avoid failed or delayed serverless evocations due to resource contention.
-
-Prisma Data Proxy is currently an Early Access feature so it isn't ready for production environments quite yet. You can follow the progress, however, to get an idea of how it works and to get a heads up when it's stable.
+Prisma Accelerate provides a solution for this problem by acting as an intermediary to a database. Serverless instances can instead connect to Prisma Accelerate which manages the connection pooling automatically to avoid failed or delayed serverless evocations due to resource contention.
 
 ## Wrapping up
 

--- a/content/11-serverless/03-serverless-challenges.mdx
+++ b/content/11-serverless/03-serverless-challenges.mdx
@@ -14,7 +14,7 @@ While [serverless computing has many benefits](https://www.prisma.io/dataguide/s
 
 <PrismaOutlinks>
 
-[Prisma's Data Proxy](https://www.prisma.io/docs/data-platform#prisma-data-proxy), now in early access, is one way to handle connection issues between your serverless applications and backend databases.  It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool.  Check it out now!
+[Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) provides one way to handle connection issues between your serverless applications and backend databases.  It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool.  Check it out now!
 
 </PrismaOutlinks>
 
@@ -52,7 +52,7 @@ Serverless functions are, by design, stateless.  That means that, while some inf
 
 You must design your functions to have all of the information they need to execute internally.  Any external state must be fetched at the beginning of invocation and exported before finishing.  Since functions may be executed in parallel, this also limits what type of state may reasonable be acted upon.  In general, the less state that your functions have to manage, the faster and cheaper they will be to execute and the less complexity you will have to manage.
 
-There are other side effects of the function's ephemeral nature as well.  If your functions need to reach out to a database system, there is a good chance you may quickly exhaust your database's connection pool.  Since each invocation of your functions can be executed in a different context, your database's connection pool can quickly drain as it responds to different invocations or tries to return resources to its pool.  Solutions like [Prism's Data Proxy](https://www.prisma.io/docs/data-platform#prisma-data-proxy) help mitigate these issues by managing the connection resources for the serverless instances in front of whatever connection pooling is in place.
+There are other side effects of the function's ephemeral nature as well.  If your functions need to reach out to a database system, there is a good chance you may quickly exhaust your database's connection pool.  Since each invocation of your functions can be executed in a different context, your database's connection pool can quickly drain as it responds to different invocations or tries to return resources to its pool.  Solutions like [Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) help mitigate these issues by managing the connection resources for the serverless instances in front of whatever connection pooling is in place.
 
 ## Provider lock-in concerns
 
@@ -101,6 +101,6 @@ By gaining familiarity with the different obstacles that you might face, you can
 
 <PrismaOutlinks>
 
-[Prisma's Data Proxy](https://www.prisma.io/docs/data-platform#prisma-data-proxy), now in early access, is one way to handle connection issues between your serverless applications and backend databases.  It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool.  Check it out now!
+[Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) provides one way to handle connection issues between your serverless applications and backend databases.  It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool.  Check it out now!
 
 </PrismaOutlinks>

--- a/content/11-serverless/04-traditional-vs-serverless-databases.mdx
+++ b/content/11-serverless/04-traditional-vs-serverless-databases.mdx
@@ -148,6 +148,6 @@ While serverless databases are not suitable for every type of application, they 
 
 <PrismaOutlinks>
 
-[Prisma's Data Proxy](https://www.prisma.io/docs/data-platform#prisma-data-proxy), now in early access, is one way to handle connection issues between your serverless applications and backend databases. It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool. Check it out now!
+[Prisma Accelerate](https://www.prisma.io/docs/data-platform/accelerate) provides one way to handle connection issues between your serverless applications and backend databases. It can help manage ephemeral connections from your serverless functions to avoid exhausting your database connection pool. Check it out now!
 
 </PrismaOutlinks>

--- a/content/11-serverless/05-serverless-glossary.mdx
+++ b/content/11-serverless/05-serverless-glossary.mdx
@@ -97,10 +97,10 @@ Checkout the [Prisma Data Platform](https://www.prisma.io/data-platform) to mana
   functionality into discrete actions.
 </AnchorItem>
 
-<AnchorItem id="prisma-data-proxy" title="Prisma Data Proxy">
+<AnchorItem id="prisma-accelerate" title="Prisma Accelerate">
   The{' '}
-  <a href="https://cloud.prisma.io/" title="Prisma Data Proxy">
-    Prisma Data Proxy
+  <a href="https://console.prisma.io/" title="Prisma Accelerate">
+    Prisma Accelerate
   </a>{' '}
   is an intermediary between an application and a database. It maintains a
   database connection pool, so that traditional databases can be reliably used


### PR DESCRIPTION
- Removes mentions of Data Proxy, and recommends Prisma Accelerate instead