### PR TITLE
Update 04-migration-strategies.mdx

### DIFF
--- a/content/03-types/02-relational/04-migration-strategies.mdx
+++ b/content/03-types/02-relational/04-migration-strategies.mdx
@@ -95,7 +95,7 @@ When using blue / green deployments with schema changes, one way to avoid these 
 
 Rather than being a deployment strategy itself, feature flags are a technique that can make implementing other strategies easier by allowing you to decouple the deployment of new functionality from the activation of that functionality. The application can continue to run the same as it originally had until it sees a different value when it checks for the flag. It can then immediately switch over to use the new functionality.
 
-In terms of introducing schema changes, feature flags are particularly valuable because your application can be designed to interact with multiple iterations of the same schema. The feature flag can be set up to indicate the version of the schema currently deployed and thus select the code that has been designed to interact with it.
+In terms of introducing schema changes, feature flags are particularly valuable because your application can be designed to interact with multiple iterations of a schema. The feature flag can be set up to indicate the version of the schema currently deployed and thus select the code that has been designed to interact with it.
 
 The disadvantages to using feature flags are often small, but should be considered. Additional infrastructure may be required to store your flag values if an appropriate key / value store is not already available. Additionally, it's possible for feature flags to increase the complexity of your code for the duration of their use. Cleaning up and simplifying code paths once the feature flag is obsolete can help keep the extra conditional logic at a minimum.
 


### PR DESCRIPTION
The schema doesn't stay the same after going through multiple iterations, that's why I am suggesting to remove "the same" which was causing confusion.