### PR TITLE
Add PlanetScale to the list of Postgres providers

### DIFF
--- a/content/04-postgresql/03-5-ways-to-host-postgresql.mdx
+++ b/content/04-postgresql/03-5-ways-to-host-postgresql.mdx
@@ -173,6 +173,7 @@ The following cloud providers offer managed PostgreSQL databases that you can pu
 - [IBM](https://www.ibm.com/cloud/databases-for-postgresql)
 - [Microsoft Azure](https://azure.microsoft.com/en-us/services/postgresql/)
 - [Neon](https://neon.tech)
+- [PlanetScale](https://planetscale.com/postgres)
 - [Prisma Postgres](https://www.prisma.io/postgres)
 - [Render](https://render.com/pricing#databases)
 - [Supabase](https://supabase.com)


### PR DESCRIPTION
PlanetScale for Postgres has been GA for a little while now.