### PR TITLE
Updates PostgreSQL documentation links and add PostgresCallout components

### DIFF
--- a/content/03-types/02-relational/01-what-is-an-orm.mdx
+++ b/content/03-types/02-relational/01-what-is-an-orm.mdx
@@ -23,6 +23,8 @@ From a developer's perspective, an ORM allows you to work with database-backed d
 
 In general, ORMs serve as an abstraction layer between the application and the database. They attempt to increase developer productivity by removing the need for boilerplate code and avoiding the use of awkward techniques that might break the idioms and ergonomics that you expect from your language of choice.
 
+<PostgresCallout />
+
 ## Do I need an ORM?
 
 While ORMs can be helpful, it's important to view them as a tool. They won't be useful in every scenario and there may be trade-offs you need to account for.

--- a/content/03-types/02-relational/02-comparing-sql-query-builders-and-orms.mdx
+++ b/content/03-types/02-relational/02-comparing-sql-query-builders-and-orms.mdx
@@ -180,6 +180,8 @@ In this article, we took a look at a few different options for interfacing with 
 
 Each of these approaches have their uses and some may be well-suited for certain types of applications than others. It is important to understand your application requirements, your organization's database knowledge, and the costs of the abstractions (or lack thereof) that you choose to implement. Overall, understanding each approach will give you the best chance of selecting the option that will be a good fit for your projects.
 
+<PostgresCallout />
+
 ## FAQ
 
 <details><summary>What is a visual SQL query builder?</summary>

--- a/content/03-types/02-relational/03-what-are-database-migrations.mdx
+++ b/content/03-types/02-relational/03-what-are-database-migrations.mdx
@@ -21,6 +21,8 @@ Migrations manage incremental, often reversible, changes to data structures in a
 
 While preventing data loss is generally one of the goals of migration software, changes that drop or destructively modify structures that currently house data can result in deletion. To cope with this, migration is often a supervised process involving inspecting the resulting change scripts and making any modifications necessary to preserve important information.
 
+<PostgresCallout />
+
 ## What are the advantages of migration tools?
 
 Migrations are helpful because they allow database schemas to evolve as requirements change. They help developers plan, validate, and safely apply schema changes to their environments. These compartmentalized changes are defined on a granular level and describe the transformations that must take place to move between various "versions" of the database.

--- a/content/03-types/02-relational/04-migration-strategies.mdx
+++ b/content/03-types/02-relational/04-migration-strategies.mdx
@@ -44,6 +44,8 @@ Lastly, schema changes can be difficult because they can have huge impacts on pe
 
 Changes that may be technically valid may impose an unacceptable performance cost that might be difficult to deduce in staging environments. If your deployment process has the chance to affect availability, that is an even larger concern.
 
+<PostgresCallout />
+
 ## Strategies
 
 With the issues mentioned above in mind, how do you decide on the best way to migrate to new schemas? There are a number of approaches to consider depending on your requirements, priorities, and application environment. In some cases, using a combination of strategies can help protect you against a wider range of potential problems.

--- a/content/03-types/02-relational/05-expand-and-contract-pattern.mdx
+++ b/content/03-types/02-relational/05-expand-and-contract-pattern.mdx
@@ -21,6 +21,8 @@ The expand and contract pattern is a process that [database administrators](/int
 
 This process can be used to make changes to many in-use interfaces, but it is especially helpful for database schema changes. Beyond just migrating data and clients to a new data structure, the expand and contract pattern is also helpful in that it allows you to rollback changes easily at most points in the process if something doesn't go as planned or if your requirements change.
 
+<PostgresCallout />
+
 ## How to use the expand and contract pattern
 
 In this section, we'll outline how you actually use the expand and contract pattern and what it is able to achieve. The individual steps involve coordination between the client applications and the schemas being used within the database. It is important to understand both the purpose of each step as well as the reason why it should be applied independently of its siblings.

--- a/content/03-types/02-relational/06-infrastructure-architecture.mdx
+++ b/content/03-types/02-relational/06-infrastructure-architecture.mdx
@@ -22,6 +22,8 @@ As a general rule, scaling up your database is a good first step as it increases
 
 Scaling up has its limitations however because the amount of resources that can be reasonably allocated to one machine is constricted. It also represents a single point of failure if no replication followers are configured to take over when problems occur. These concerns are addressed by some of the other scaling options.
 
+<PostgresCallout />
+
 ## Command query responsibility segregation (CQRS) and Read-only replicas
 
 The other primary way of scaling your database infrastructure is to scale out. _Scaling out_ means that instead of increasing the capacity of a single server, you increase the number of servers dedicated to serving a specific need. So you add capacity by adding additional machines to your infrastructure.

--- a/content/04-postgresql/01-benefits-of-postgresql.mdx
+++ b/content/04-postgresql/01-benefits-of-postgresql.mdx
@@ -52,6 +52,8 @@ You can find out more about the features that PostgreSQL supports with the follo
 - [SQL Feature comparison with other databases](https://www.sql-workbench.eu/dbms_comparison.html)
 - [Wikipedia's database comparison tables](https://en.wikipedia.org/wiki/Comparison_of_relational_database_management_systems)
 
+<PostgresCallout />
+
 ## Object-oriented database features
 
 One of the most fundamental ways that PostgreSQL is different from most other relational databases comes from its core design.
@@ -115,6 +117,8 @@ This focus on community-driven development has resulted in great participation f
 PostgreSQL has gained a great reputation as a powerful, feature-rich choice for relational data. Valuing stability, functionality, and standards conformance, PostgreSQL checks all of the right boxes for many projects. Similarly, if you require flexibility in how you can represent data and want to be able to use a variety of tools and languages, PostgreSQL is also a good choice.
 
 PostgreSQL is notable for offering excellent implementation of core relational features while not limiting itself to the boundaries of traditional RDBMSs. While no database can serve every need, PostgreSQL is an excellent option that is versatile enough to suit many use cases.
+
+If you've decided PostgreSQL is the right fit, the next step is deciding [where to host your PostgreSQL database](/postgresql/5-ways-to-host-postgresql) — the options range from self-managed installs to fully managed services, each with different trade-offs in cost, control, and operational overhead.
 
 <PrismaOutlinks>
 

--- a/content/04-postgresql/02-getting-to-know-postgresql.mdx
+++ b/content/04-postgresql/02-getting-to-know-postgresql.mdx
@@ -16,7 +16,7 @@ This guide will go over PostgreSQL's architecture and attributes to give you a g
 
 Like many relational database systems, PostgreSQL's basic architecture follows the client-server model.
 
-The main PostgreSQL program runs as a [service](https://www.prisma.io/dataguide/postgresql/setting-up-a-local-postgresql-database) that is responsible for defining data structures, storing data, and responding to queries. This daemon listens for connections from clients, who can authenticate themselves and then send instructions to the server. The server responds with messages indicating success, failure, query results, or other appropriate information.
+The main PostgreSQL program runs as a [service](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/setting-up-a-local-postgresql-database) that is responsible for defining data structures, storing data, and responding to queries. This daemon listens for connections from clients, who can authenticate themselves and then send instructions to the server. The server responds with messages indicating success, failure, query results, or other appropriate information.
 
 This architecture allows a PostgreSQL system to serve many different clients who can connect locally or over the network. The master PostgreSQL process forks a new process for each client connection it receives. Because of this, each fork is dedicated to a single client connection, so the number of connections, forks, and database sessions align with one another.
 
@@ -27,11 +27,13 @@ Concepts:
 - **fork**: A fork is a clone of a running process, often used to help control resource usage, privilege level, and create a new execution environment.
 - **database session**: A database session is a single, continuous connection between a database server and client. Sessions have their own context that persists for the life of the session, allowing for some level of state and configuration on a per-session basis.
 
+<PostgresCallout />
+
 ## PostgreSQL's default client: `psql`
 
 Users can connect to PostgreSQL servers using a variety of clients. The default command line client that is implemented as part of the PostgreSQL distribution is called `psql`.
 
-The [`psql` client](https://www.prisma.io/dataguide/postgresql/connecting-to-postgresql-databases) operates can connect to local or remote databases and either process queries as a batch or interactively. For automated use cases, authentication credentials can be stored in a [dedicated authentication file](https://www.postgresql.org/docs/current/libpq-pgpass.html) and queries can be read by the client from a file.
+The [`psql` client](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connecting-to-postgresql-databases) operates can connect to local or remote databases and either process queries as a batch or interactively. For automated use cases, authentication credentials can be stored in a [dedicated authentication file](https://www.postgresql.org/docs/current/libpq-pgpass.html) and queries can be read by the client from a file.
 
 Interactive `psql` sessions drop the user at a PostgreSQL command prompt upon authenticating. From there, you can send SQL to the client and either view the results in your terminal window or pipe them to an output file.
 

--- a/content/04-postgresql/03-5-ways-to-host-postgresql.mdx
+++ b/content/04-postgresql/03-5-ways-to-host-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: '5 ways to host PostgreSQL databases'
 metaTitle: '5 Ways to Host PostgreSQL Databases | PostgreSQL Hosting Guide'
-metaDescription: 'From self-managed to managed services, there are many ways to get PostgreSQL servers for your projects. Find out the pros and cons of various hosting options with our guide.'
+metaDescription: 'Compare PostgreSQL hosting options — self-managed, Docker, cloud-provider managed like AWS RDS, and fully managed Prisma Postgres — with a decision table, a "when to choose" guide, and an FAQ to help you pick the right one.'
 authors: ['justinellingwood', 'danielnorman']
 metaImage: '/social/generic-postgresql.png'
 toc: false
@@ -20,12 +20,16 @@ This guide will cover different ways to run PostgreSQL and their respective bene
 - [Managed services](#managed-services)
   - [Databases managed by cloud providers](#databases-managed-by-cloud-providers)
   - [Third-party managed databases](#third-party-managed-databases)
+- [Comparing your options at a glance](#comparing-your-options-at-a-glance)
+- [When to choose Prisma Postgres](#when-to-choose-prisma-postgres)
+- [Create your first Prisma Postgres database](#create-your-first-prisma-postgres-database)
+- [Frequently asked questions](#frequently-asked-questions)
 
 ## Self-managed PostgreSQL
 
 The most flexible and simplest to describe option is self-hosting your PostgreSQL server. Self-hosting PostgreSQL means that you install and configure your databases on computers that you control, just like any other piece of software.
 
-Self-hosting gives you a lot of choice as to where you will install and run your databases. If you choose one of the options in this section, you can use this guide to learn [how to install PostgreSQL on your systems](/postgresql/setting-up-a-local-postgresql-database).
+Self-hosting gives you a lot of choice as to where you will install and run your databases. If you choose one of the options in this section, you can use this guide to learn [how to install PostgreSQL on your systems](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/setting-up-a-local-postgresql-database).
 
 ### Installing PostgreSQL on your local development computer
 
@@ -140,6 +144,8 @@ While Docker simplifies certain aspects of running PostgreSQL, there are a few t
 #### Containers and Kubernetes
 
 With [Kubernetes](https://kubernetes.io/), you can run Docker containers on a cluster consisting of multiple servers. If one server in the cluster needs to be taken down for maintenance, Kubernetes will move the PostgreSQL container to another server as long as the underlying data partition is accessible. You can also run your application that uses PostgreSQL on Kubernetes, which can reduce network latency between the application and PostgreSQL.
+
+<PostgresCallout />
 
 ## Managed services
 
@@ -263,6 +269,69 @@ Here is an overview of how the various options discussed here compare to one ano
 ![Chart comparing PostgreSQL hosting options](../dataguide-images/postgresql/ways-to-host-postgresql-databases/comparison-chart.png)
 
 The right choice for hosting your database depends significantly on your applications' requirements, the stage of your development, and your ability to manage PostgreSQL on your own. Different choices offer trade-offs between these factors that make them more appropriate at certain times or for certain organizations.
+
+## Comparing your options at a glance
+
+The table below summarizes how the main hosting approaches compare across the factors that usually drive the decision. "Ops burden" is how much of the database's day-to-day operation — patching, backups, scaling, pooling — falls on you versus the provider.
+
+| Option                                                 | Setup time       | Ops burden                        | Connection pooling          | Backups   | Scaling      | Best for                                                   |
+| ------------------------------------------------------ | ---------------- | --------------------------------- | --------------------------- | --------- | ------------ | ---------------------------------------------------------- |
+| **Self-managed (local / Docker)**                      | Minutes          | You (all of it)                   | DIY (e.g. PgBouncer)        | You       | Manual       | Local development, learning, prototypes                    |
+| **Self-managed on a server / VM**                      | Hours to days    | You (high)                        | DIY                         | You       | Manual       | Teams needing full OS-level control and in-house expertise |
+| **Cloud-provider managed (AWS RDS, Cloud SQL, Azure)** | Minutes to hours | Provider runs it, you tune & size | Often an add-on or self-run | Automated | Configurable | Teams already standardized on a cloud                      |
+| **Third-party managed Postgres**                       | Minutes          | Provider                          | Varies by provider          | Automated | Good         | Multi-cloud or portability needs                           |
+| **Prisma Postgres (fully managed)**                    | Seconds          | Fully managed                     | Built in                    | Automated | Automatic    | Serverless/edge apps, fast starts, TypeScript stacks       |
+
+No single row is "best" — a local install is the right tool for early development, and a self-managed server is the right tool when you need full control. The table is meant to help you match the stage and constraints of your project to an approach.
+
+## When to choose Prisma Postgres
+
+[Prisma Postgres](https://www.prisma.io/postgres?utm_source=dataguide&utm_medium=body_link&utm_campaign=postgres_hosting&utm_content=5-ways-to-host-postgresql:product) is a fully managed PostgreSQL service designed to remove the operational work of running Postgres. It tends to be a good fit when:
+
+- **You're building for serverless or edge.** Connection pooling is built in, so functions can use a normal Postgres connection string without you running a separate pooler.
+- **You want to start in seconds with zero infrastructure.** Databases are provisioned instantly — there are no instances, networks, or backups to configure first.
+- **You're working in a TypeScript/JavaScript stack.** It pairs directly with [Prisma ORM](https://www.prisma.io/docs/orm) for an end-to-end type-safe data layer.
+- **You want slow queries surfaced for you.** Built-in Query Insights highlights expensive queries without you wiring up separate monitoring.
+- **You want backups handled automatically** rather than scripting and testing your own.
+
+It's likely **not** the right fit if you need OS-level access to the database host, depend on a specific PostgreSQL extension or region your provider must support, or have already invested heavily in a self-managed setup that meets your needs. As with any managed service, confirm it supports the extensions, regions, and compliance requirements your project depends on.
+
+## Create your first Prisma Postgres database
+
+You can have a working database in well under a minute:
+
+1. **Sign in to the [Prisma Console](https://console.prisma.io/login?utm_source=dataguide&utm_medium=body_link&utm_campaign=postgres_hosting&utm_content=5-ways-to-host-postgresql:create).** A free tier is available to get started.
+2. **Create a new database** and choose the region closest to your application.
+3. **Copy the connection string** shown for your new database.
+4. **Connect from your app.** Use it like any Postgres connection string, or with Prisma ORM set it as your `DATABASE_URL` and run your first migration.
+
+The [Prisma Postgres documentation](https://www.prisma.io/docs/postgres) walks through each step in detail, and [pricing](https://www.prisma.io/pricing?utm_source=dataguide&utm_medium=body_link&utm_campaign=postgres_hosting&utm_content=5-ways-to-host-postgresql:pricing) covers the free tier and usage-based plans as you grow.
+
+## Frequently asked questions
+
+### Is there a free way to host PostgreSQL?
+
+Yes. For development, a local install or Docker container is free aside from your own machine's resources. For a hosted database, several managed providers offer a free tier — including Prisma Postgres, which has a free tier you can [start on](https://console.prisma.io/login?utm_source=dataguide&utm_medium=body_link&utm_campaign=postgres_hosting&utm_content=5-ways-to-host-postgresql:faq-free) before moving to usage-based pricing.
+
+### What's the best PostgreSQL hosting for serverless or edge apps?
+
+Serverless and edge environments open many short-lived connections, which can exhaust a traditional database's connection limit. A managed option with built-in connection pooling handles this without extra setup. Prisma Postgres includes pooling so your functions can use a standard connection string directly.
+
+### Do I need a separate connection pooler?
+
+With self-managed PostgreSQL you typically run a pooler such as PgBouncer yourself. Some managed services offer pooling as an add-on, while Prisma Postgres includes it by default, so there's nothing extra to deploy.
+
+### How are backups handled?
+
+With self-managed PostgreSQL, backups are your responsibility to schedule, store, and test. Managed services — cloud-provider databases, third-party providers, and Prisma Postgres — automate backups for you, though you should still confirm the retention and restore options match your needs.
+
+### Can I develop locally and deploy to a hosted database?
+
+Yes, and it's a common workflow: develop against a local or Docker PostgreSQL instance, then point your app at a hosted database for staging and production by swapping the connection string. Prisma Postgres supports both local development and hosted databases.
+
+### Is managed PostgreSQL production-ready?
+
+Yes. Managed PostgreSQL — whether from a cloud provider or a service like Prisma Postgres — runs the same PostgreSQL you'd run yourself, with the provider handling high availability, backups, and scaling. Confirm the specific guarantees (uptime SLA, backup retention, supported versions and extensions) before committing.
 
 <PrismaOutlinks>
 

--- a/content/04-postgresql/04-setting-up-a-local-postgresql-database.mdx
+++ b/content/04-postgresql/04-setting-up-a-local-postgresql-database.mdx
@@ -111,6 +111,8 @@ When you are finished, exit the session by typing:
 \quit
 ```
 
+<PostgresCallout />
+
 ## Setting up PostgreSQL on macOS
 
 The PostgreSQL project provides a native macOS installer to install and configure your database.

--- a/content/04-postgresql/05-setting-up-postgresql-on-rds.mdx
+++ b/content/04-postgresql/05-setting-up-postgresql-on-rds.mdx
@@ -10,6 +10,8 @@ authors: ['justinellingwood']
 
 Amazon Web Service's Relational Database Service (RDS) is a popular option for database hosting because of its flexibility and robust feature set. Development teams can provision new databases for personal use, staging environments, and production workloads and integrate them seamlessly with the rest of AWS's product suite.
 
+RDS is just one of [several ways to host PostgreSQL](/postgresql/5-ways-to-host-postgresql). It's worth weighing it against self-managed and fully managed alternatives before committing, since each option differs in setup effort, ongoing operations, and how much control you retain.
+
 In this guide, we'll discuss how to use Amazon's RDS to configure a production-capable PostgreSQL database. We will walk through important options in the creation process, discuss trade-offs, and configure a reliable, robust database setup designed for early production deployments.
 
 ## Why Amazon Web Service's RDS?
@@ -26,6 +28,8 @@ Some of the core features that make RDS an attractive option include:
 - **Costs based on usage**: costs are tied directly to the features and usage of the database, alleviating uncertainty over long-term capacity planning.
 
 With these benefits in mind, let's get started setting up a PostgreSQL database instance to walk through the process.
+
+<PostgresCallout />
 
 ## Starting the database creation process
 
@@ -367,7 +371,7 @@ With this information, you can connect to your PostgreSQL instance. For an examp
 postgresql://postgres:Pa38iSJWm8qtq90LnmZ8@production-db1.cddm7tgh3j5j.us-east-1.rds.amazonaws.com:5432/postgres
 ```
 
-You can learn more about how to construct connection URIs from connection details in our guide on [PostgreSQL connection URIs](/postgresql/short-guides/connection-uris).
+You can learn more about how to construct connection URIs from connection details in our guide on [PostgreSQL connection URIs](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris).
 
 ## Conclusion
 

--- a/content/04-postgresql/06-connecting-to-postgresql-databases.mdx
+++ b/content/04-postgresql/06-connecting-to-postgresql-databases.mdx
@@ -14,7 +14,7 @@ Because of this, you need to understand how to connect as a client by providing 
 
 In a companion guide, you can find out how to [configure PostgreSQL's authentication to meet your project's needs](/postgresql/authentication-and-authorization/configuring-user-authentication). Consider reading both guides for a more complete picture of how authentication works in PostgreSQL.
 
-If your database client or library requests a connection URI, you may want to look at our guide on [understanding PostgreSQL connection URIs](https://www.prisma.io/dataguide/postgresql/short-guides/connection-uris) instead.
+If your database client or library requests a connection URI, you may want to look at our guide on [understanding PostgreSQL connection URIs](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris) instead.
 
 ## Basic information about the `psql` client
 
@@ -26,6 +26,8 @@ The way that you connect depends on the configuration of the PostgreSQL server a
 - **remote connection**: where the client is connecting to a network-accessible PostgreSQL instance running on a different computer
 
 Let's start with connecting to a database from the same computer.
+
+<PostgresCallout />
 
 ## Connecting to a local database with `psql`
 
@@ -102,7 +104,7 @@ Upon pressing enter, you'd be prompted a password where you can authenticate wit
 
 ### Passing connection information to `psql` with a connection string
 
-This same information can also be encoded into a [PostgreSQL _connection string_](https://www.prisma.io/dataguide/postgresql/short-guides/connection-uris). A connection string provides the same information in a single URI string that uses certain characters as delimiters between the different fields.
+This same information can also be encoded into a [PostgreSQL _connection string_](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris). A connection string provides the same information in a single URI string that uses certain characters as delimiters between the different fields.
 
 Connection strings have the following general format:
 

--- a/content/04-postgresql/07-authentication-and-authorization/01-intro-to-authn-and-authz.mdx
+++ b/content/04-postgresql/07-authentication-and-authorization/01-intro-to-authn-and-authz.mdx
@@ -8,125 +8,127 @@ authors: ['justinellingwood']
 
 ## Introduction
 
-Controlling access to your systems and data is essential for maintaining the security and integrity of your data.  PostgreSQL provides a number of features to help you manage these concerns and learning how they work is an important part of managing your databases.
+Controlling access to your systems and data is essential for maintaining the security and integrity of your data. PostgreSQL provides a number of features to help you manage these concerns and learning how they work is an important part of managing your databases.
 
-Controlling access to resources and defining who can do what to what entities is an area known as authentication and authorization.  This guide explores the tools PostgreSQL furnishes to control access to and within the system with the goal giving an overview of each component and the overall functions they support.
+Controlling access to resources and defining who can do what to what entities is an area known as authentication and authorization. This guide explores the tools PostgreSQL furnishes to control access to and within the system with the goal giving an overview of each component and the overall functions they support.
 
 ## What are authentication and authorization?
 
 Before diving into those specific tools that PostgreSQL provides, it's helpful to review what exactly authentication and authorization are and why they're important.
 
-### What is authentication? 
+### What is authentication?
 
-[*Authentication*](/intro/database-glossary#authentication) is a process of validating an identity.  In computing, this generally means verifying that a user or entity is who they say they are.
+[_Authentication_](/intro/database-glossary#authentication) is a process of validating an identity. In computing, this generally means verifying that a user or entity is who they say they are.
 
 Authentication generally involves challenging a user to provide something secret they know (like passwords), something unique that they have (like the code from a cellphone authentication app), or something that is a feature of their unique identity (like fingerprint authentication).
 
 Familiar ways of proving a user's identity include:
 
-* Passwords
-* Secret keys
-* Security Certificates
-* Software or hardware tokens
-* Fingerprint reading
+- Passwords
+- Secret keys
+- Security Certificates
+- Software or hardware tokens
+- Fingerprint reading
 
-Authentication is an important requirement of almost all multi-user systems.  Different people or entities (like automated tools) require different capabilities and access to data, and establishing identity is the first step in providing individualized experiences for clients.  Authentication is a way of confirming that the accounts within your system are usable only by the real world people or entities they are supposed to represent.
+Authentication is an important requirement of almost all multi-user systems. Different people or entities (like automated tools) require different capabilities and access to data, and establishing identity is the first step in providing individualized experiences for clients. Authentication is a way of confirming that the accounts within your system are usable only by the real world people or entities they are supposed to represent.
 
 ### What is authorization?
 
-While authentication is concerned with validating identity, [*authorization*](/intro/database-glossary#authorization) focuses on controlling what capabilities are associated with those identities or accounts.  Once you know who someone is, the authorization functionality determines what they can do.
+While authentication is concerned with validating identity, [_authorization_](/intro/database-glossary#authorization) focuses on controlling what capabilities are associated with those identities or accounts. Once you know who someone is, the authorization functionality determines what they can do.
 
 Definitions within authorization policies typically are comprised of three components:
 
-* The subject: the user, account, or identity performing the action
-* The action: the specific function or activity to be performed
-* The object: the resource, entity, or scope targeted by the action
+- The subject: the user, account, or identity performing the action
+- The action: the specific function or activity to be performed
+- The object: the resource, entity, or scope targeted by the action
 
-Authorization policies can define broad, general rules as well as specific, granular exceptions depending on the level of control the system provides.  Some policies map capabilities to user "classes" or "roles" instead of to individual users to establish set authorization levels.
+Authorization policies can define broad, general rules as well as specific, granular exceptions depending on the level of control the system provides. Some policies map capabilities to user "classes" or "roles" instead of to individual users to establish set authorization levels.
 
-Authorization is the mechanism by which a system can lock down capabilities and access to resources based on who you are.  As such, it has important relationships with user management, resource management, and security.
+Authorization is the mechanism by which a system can lock down capabilities and access to resources based on who you are. As such, it has important relationships with user management, resource management, and security.
+
+<PostgresCallout />
 
 ## How does PostgreSQL configure authentication and authorization?
 
-PostgreSQL has a few interrelated concepts that, together, fulfill its access management requirements to authenticate and authorize user actions.  These concepts work in tandem to establish who a client is an agent for and what they can do within PostgreSQL.
+PostgreSQL has a few interrelated concepts that, together, fulfill its access management requirements to authenticate and authorize user actions. These concepts work in tandem to establish who a client is an agent for and what they can do within PostgreSQL.
 
 In short, PostgreSQL uses the following framework to authenticate and authorize users to database clusters:
 
-* Users and user classes are defined within the system as *roles*.
-* The methods of authenticating to a role are defined in the *`pg_hba.conf` file* (the host-based authentication file).
-* The role's capabilities and level of access is defined by the *privileges* granted to them directly, through role membership, or through object ownership.
+- Users and user classes are defined within the system as _roles_.
+- The methods of authenticating to a role are defined in the _`pg_hba.conf` file_ (the host-based authentication file).
+- The role's capabilities and level of access is defined by the _privileges_ granted to them directly, through role membership, or through object ownership.
 
 Exploring these three interrelated areas more in-depth can help you learn how each of them contributes to PostgreSQL's access management functionality.
 
 ## Roles
 
-PostgreSQL does not have separate entities to represent users and groups.  Instead, both user accounts and user groups are implemented as a single, unified concept called roles.  **Roles** are a flexible identity used to represent individual users as well as groups of users.
+PostgreSQL does not have separate entities to represent users and groups. Instead, both user accounts and user groups are implemented as a single, unified concept called roles. **Roles** are a flexible identity used to represent individual users as well as groups of users.
 
-Roles are the anchor point within PostgreSQL that determine who authentication and authorization policies apply to.  Any policy that does not apply universally requires a notion of identity to define who to restrict and who to allow.  Each connection to a PostgreSQL database is associated with a specific role that determines its initial level of access.
+Roles are the anchor point within PostgreSQL that determine who authentication and authorization policies apply to. Any policy that does not apply universally requires a notion of identity to define who to restrict and who to allow. Each connection to a PostgreSQL database is associated with a specific role that determines its initial level of access.
 
-Authorization policies determine what powers each role has within the database cluster, including what commands it can execute, what resources it can access, and what features it can use.  Users authenticate to roles to gain access to those privileges.
+Authorization policies determine what powers each role has within the database cluster, including what commands it can execute, what resources it can access, and what features it can use. Users authenticate to roles to gain access to those privileges.
 
-Administrators can make roles as *members* of other roles to give the member access to the "container" role's privileges.  This flexibility lets you treat some roles as analogs for user accounts and other roles as analogs for user groups, classes, or duties.
+Administrators can make roles as _members_ of other roles to give the member access to the "container" role's privileges. This flexibility lets you treat some roles as analogs for user accounts and other roles as analogs for user groups, classes, or duties.
 
-A single role can operate as both a container and a member to implement more complex policy.  In general, roles intended to be used as user agents have defined authentication policies, with their level of authorization determined by their own privileges, the privileges of roles they are members of, and the objects they own.  In contrast, roles that are meant to work as groups typically do not have associated authorization.
+A single role can operate as both a container and a member to implement more complex policy. In general, roles intended to be used as user agents have defined authentication policies, with their level of authorization determined by their own privileges, the privileges of roles they are members of, and the objects they own. In contrast, roles that are meant to work as groups typically do not have associated authorization.
 
 The article dedicated to roles covers [how to define and configure roles within PostgreSQL](/postgresql/authentication-and-authorization/role-management).
 
 ## The `pg_hba.conf` file
 
-The `pg_hba.conf` file is the main component that defines authentication policies within PostgreSQL.  In this context, "HBA" stands for host-based authentication in reference to the policies that determine whether connections to the PostgreSQL host are accepted.
+The `pg_hba.conf` file is the main component that defines authentication policies within PostgreSQL. In this context, "HBA" stands for host-based authentication in reference to the policies that determine whether connections to the PostgreSQL host are accepted.
 
-The `pg_hba.conf` file allows administrators to define granular authentication requirements including through a matching system.  Connections are tested against the matching criteria to determine if an authentication policy should be used.
+The `pg_hba.conf` file allows administrators to define granular authentication requirements including through a matching system. Connections are tested against the matching criteria to determine if an authentication policy should be used.
 
-The policies are defined, one per line, with fields separated by white space.  Each policy defines matching criteria and authentication requirements.
+The policies are defined, one per line, with fields separated by white space. Each policy defines matching criteria and authentication requirements.
 
 The matching criteria can check against criteria like:
 
-* the way clients connect
-* the role they are attempting to authenticate to
-* the database they are attempting to access
-* the client's IP address and network properties
+- the way clients connect
+- the role they are attempting to authenticate to
+- the database they are attempting to access
+- the client's IP address and network properties
 
-The first authentication policy that matches the connection is used to authenticate.  PostgreSQL offers a wide variety of authentication methods of varying levels of sophistication ranging from passwords and certificates to coordinating with external systems like [LDAP](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) and [RADIUS](https://en.wikipedia.org/wiki/RADIUS) servers.
+The first authentication policy that matches the connection is used to authenticate. PostgreSQL offers a wide variety of authentication methods of varying levels of sophistication ranging from passwords and certificates to coordinating with external systems like [LDAP](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) and [RADIUS](https://en.wikipedia.org/wiki/RADIUS) servers.
 
-Since only a single policy (the first matching one) is consulted for each connection, controlling the specificity and ordering of policies is very important.  Improper ordering can lead to client connections matching the incorrect policy, which can either prevent users from accessing the system or allow access to connections inadvertently.
+Since only a single policy (the first matching one) is consulted for each connection, controlling the specificity and ordering of policies is very important. Improper ordering can lead to client connections matching the incorrect policy, which can either prevent users from accessing the system or allow access to connections inadvertently.
 
 Follow our guide on [configuring authentication in PostgreSQL](/postgresql/authentication-and-authorization/configuring-user-authentication) to learn how to configure effective `pg_hba.conf` policies.
 
 ## The PostgreSQL privilege and role attribute system
 
-The last part of PostgreSQL's authorization story are the features that define what each role can do.  There are a number of mechanisms that change the level of access or control that various roles have.
+The last part of PostgreSQL's authorization story are the features that define what each role can do. There are a number of mechanisms that change the level of access or control that various roles have.
 
 ### Role attributes
 
-The first way that PostgreSQL allows you to alter a role's capabilities is with [role attributes](https://www.postgresql.org/docs/current/role-attributes.html).  *Role attributes* define privileges that a role has across the entire database cluster.  These are mostly special administrator-level capabilities or an expression of the degree of limitations on the account.
+The first way that PostgreSQL allows you to alter a role's capabilities is with [role attributes](https://www.postgresql.org/docs/current/role-attributes.html). _Role attributes_ define privileges that a role has across the entire database cluster. These are mostly special administrator-level capabilities or an expression of the degree of limitations on the account.
 
-The most powerful attribute is the `superuser` attribute that gives a role the ability to bypass any authorization checks within PostgreSQL, in effect, allowing it total control over the system.  Other attributes allow more narrowly defined privileges, like the ability to create roles and databases with the `createrole` and `createdb` attributes, respectively.
+The most powerful attribute is the `superuser` attribute that gives a role the ability to bypass any authorization checks within PostgreSQL, in effect, allowing it total control over the system. Other attributes allow more narrowly defined privileges, like the ability to create roles and databases with the `createrole` and `createdb` attributes, respectively.
 
-Attributes can also affect how the role is allowed to access the system.  For instance, the `login` attribute is required to be able to authenticate in an initial connection.  Likewise, a `connection limit` can be set to control the number of simultaneous connections a role can make.
+Attributes can also affect how the role is allowed to access the system. For instance, the `login` attribute is required to be able to authenticate in an initial connection. Likewise, a `connection limit` can be set to control the number of simultaneous connections a role can make.
 
 Role attributes serve as the primary means of defining a role's global capabilities.
 
-PostgreSQL uses another system to determine a role's privileges in regard to specific database objects like databases, tables, and columns.  A role's relationship with database objects is a function of its ownership status and the privileges granted to it.
+PostgreSQL uses another system to determine a role's privileges in regard to specific database objects like databases, tables, and columns. A role's relationship with database objects is a function of its ownership status and the privileges granted to it.
 
 ### Object ownership
 
-Object ownership is the first determining factor.  By default, roles own any objects that they create themselves.  Ownership gives you full access to the object including special privileges like the ability to delete or modify the object itself.  Only `superuser` roles can delete or modify objects that they do not own.
+Object ownership is the first determining factor. By default, roles own any objects that they create themselves. Ownership gives you full access to the object including special privileges like the ability to delete or modify the object itself. Only `superuser` roles can delete or modify objects that they do not own.
 
-Each database object has exactly one owner.  If you want multiple roles to have owner privileges of a database object, you will need to make them both members of a single role and give that role ownership.
+Each database object has exactly one owner. If you want multiple roles to have owner privileges of a database object, you will need to make them both members of a single role and give that role ownership.
 
 ### Granted object privileges
 
 Roles that are not the object owner can be given different levels of access using PostgreSQL's privilege granting system.
 
-[Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) on database objects are managed with the `GRANT` and `REVOKE` commands.  The `GRANT` command, when used in this context, adds privileges to roles on specific database objects.  On the opposite side, the `REVOKE` command removes those same privileges from roles.
+[Privileges](https://www.postgresql.org/docs/current/ddl-priv.html) on database objects are managed with the `GRANT` and `REVOKE` commands. The `GRANT` command, when used in this context, adds privileges to roles on specific database objects. On the opposite side, the `REVOKE` command removes those same privileges from roles.
 
-As mentioned earlier, only the object owner and `superuser` roles can delete or modify the object itself.  However, granular privileges can be assigned for data or other objects within the object.  With tables, for example, the `SELECT`, `INSERT`, `UPDATE`, and `DELETE` privileges control whether roles can view, add, modify, and remove data, respectively.
+As mentioned earlier, only the object owner and `superuser` roles can delete or modify the object itself. However, granular privileges can be assigned for data or other objects within the object. With tables, for example, the `SELECT`, `INSERT`, `UPDATE`, and `DELETE` privileges control whether roles can view, add, modify, and remove data, respectively.
 
-The types of privileges available depend on the database object in question.  For instance, the `REFERENCES` privilege, which allows the role to create foreign key constraints related to the object, is limited to use on table or table column objects.  That's because defining foreign constraint privileges on a sequence, for example, doesn't make sense.  For a summary of which privileges and database objects can be used together, [take a look at Table 5.1 and Table 5.2 in PostgreSQL's documentation on privileges](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE).
+The types of privileges available depend on the database object in question. For instance, the `REFERENCES` privilege, which allows the role to create foreign key constraints related to the object, is limited to use on table or table column objects. That's because defining foreign constraint privileges on a sequence, for example, doesn't make sense. For a summary of which privileges and database objects can be used together, [take a look at Table 5.1 and Table 5.2 in PostgreSQL's documentation on privileges](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE).
 
 Check out our guide on [managing privileges within PostgreSQL](/postgresql/authentication-and-authorization/managing-privileges) to learn more about how to use PostgreSQL's grant system.
 
 ## Conclusion
 
-PostgreSQL's authentication and authorization systems may initially seem complex when viewed all together.  However, the individual components to the system are all well-defined and mostly associated with a single concern.  Understanding how these systems fit together to implement powerful and flexible access management is essential for keeping your databases and the data they hold safe.
+PostgreSQL's authentication and authorization systems may initially seem complex when viewed all together. However, the individual components to the system are all well-defined and mostly associated with a single concern. Understanding how these systems fit together to implement powerful and flexible access management is essential for keeping your databases and the data they hold safe.

--- a/content/04-postgresql/07-authentication-and-authorization/02-role-management.mdx
+++ b/content/04-postgresql/07-authentication-and-authorization/02-role-management.mdx
@@ -1,61 +1,62 @@
 ---
 title: 'Managing roles and role attributes in PostgreSQL'
 metaTitle: 'Managing roles & attributes with PostgreSQL | Prisma'
-metaDescription: "PostgreSQL roles are a combination of the ideas of users and groups into a single, flexible entity.  This guide will cover what roles are and how to manage them within a PostgreSQL database cluster."
+metaDescription: 'PostgreSQL roles are a combination of the ideas of users and groups into a single, flexible entity.  This guide will cover what roles are and how to manage them within a PostgreSQL database cluster.'
 metaImage: '/social/generic-postgresql.png'
 authors: ['justinellingwood']
 ---
 
 ## Introduction
 
-PostgreSQL uses various mechanisms to implement [authentication](/intro/database-glossary#authentication), [authorization](/intro/database-glossary#authorization), and object ownership within database clusters.  Core among these is the concept of roles.
+PostgreSQL uses various mechanisms to implement [authentication](/intro/database-glossary#authentication), [authorization](/intro/database-glossary#authorization), and object ownership within database clusters. Core among these is the concept of roles.
 
-PostgreSQL roles are a combination of the ideas of users and groups into a single, flexible entity.  They are the persona that user's adopt within the database system, are the entity by which the authentication system accepts or denies connections, and the subject of privilege management rules of all scopes.
+PostgreSQL roles are a combination of the ideas of users and groups into a single, flexible entity. They are the persona that user's adopt within the database system, are the entity by which the authentication system accepts or denies connections, and the subject of privilege management rules of all scopes.
 
-This guide will cover what roles are and how to manage them within a PostgreSQL database cluster.  More specifically, this guide will cover role management as it relates to role attributes.  For a more broad overview of how roles fit into the larger picture, take a look at the [introduction to authentication and authorization guide](/postgresql/authentication-and-authorization/intro-to-authn-and-authz).  To learn how to change role privileges on specific database objects, check out our guide on [role grants](/postgresql/authentication-and-authorization/managing-privileges).
+This guide will cover what roles are and how to manage them within a PostgreSQL database cluster. More specifically, this guide will cover role management as it relates to role attributes. For a more broad overview of how roles fit into the larger picture, take a look at the [introduction to authentication and authorization guide](/postgresql/authentication-and-authorization/intro-to-authn-and-authz). To learn how to change role privileges on specific database objects, check out our guide on [role grants](/postgresql/authentication-and-authorization/managing-privileges).
 
 ## What are roles?
 
 In PostgreSQL, a role is a grouping of a specific set of capabilities, permissions, and "owned" entities. Instead of having distinct concepts of "users" and "groups", PostgreSQL uses roles to represent both of these ideas. A role can correspond to an individual person in the real world, or it can operate as a group with certain access that other roles can become members of.
 
-Roles are the anchor point within PostgreSQL that determine who authentication and authorization policies apply to.  Any policy that does not apply universally requires a notion of identity to define who to restrict and who to allow.  In PostgreSQL, this identity is represented by roles.
+Roles are the anchor point within PostgreSQL that determine who authentication and authorization policies apply to. Any policy that does not apply universally requires a notion of identity to define who to restrict and who to allow. In PostgreSQL, this identity is represented by roles.
 
-PostgreSQL's authentication system has a number of different components, each of which are tied to roles.  In order to be used for the initial connection to the database cluster, roles must first have the `LOGIN` attribute set.  The authentication rules themselves are defined in the host-based configuration file called `pg_hba.conf`.  Each rule defines methods of authentication that may be scoped to the individual role.  For roles that are configured for password authentication must have a password attribute set so the system can validate the supplied user password.
+PostgreSQL's authentication system has a number of different components, each of which are tied to roles. In order to be used for the initial connection to the database cluster, roles must first have the `LOGIN` attribute set. The authentication rules themselves are defined in the host-based configuration file called `pg_hba.conf`. Each rule defines methods of authentication that may be scoped to the individual role. For roles that are configured for password authentication must have a password attribute set so the system can validate the supplied user password.
 
-In terms of authorization, roles are defined at the database cluster level, which in PostgreSQL, means that they are shared between databases.  Since roles span databases, the authorization system controls the level of access each role has to each database entity.  Because roles can represent groups of people, there is a great deal of flexibility in how access can be configured.
+In terms of authorization, roles are defined at the database cluster level, which in PostgreSQL, means that they are shared between databases. Since roles span databases, the authorization system controls the level of access each role has to each database entity. Because roles can represent groups of people, there is a great deal of flexibility in how access can be configured.
 
-Roles are also essential to the concept of object ownership within PostgreSQL.  Each database and table, for instance, have exactly one role configured as the owner.  Other than `superusers`, the owner role is the only role that can modify or delete the actual object.
+Roles are also essential to the concept of object ownership within PostgreSQL. Each database and table, for instance, have exactly one role configured as the owner. Other than `superusers`, the owner role is the only role that can modify or delete the actual object.
 
-In summary, roles are at the core of most practical database operations.  Their flexibility allows them to act both as user identifiers and user classes.  Every action within the database cluster is checked against the role's privileges and the success of each connection to the database cluster is determined by the role one authenticates to.  It is important to get a good handle on role management because of its importance within so many core operations.
+In summary, roles are at the core of most practical database operations. Their flexibility allows them to act both as user identifiers and user classes. Every action within the database cluster is checked against the role's privileges and the success of each connection to the database cluster is determined by the role one authenticates to. It is important to get a good handle on role management because of its importance within so many core operations.
 
+<PostgresCallout />
 
 ## Role attributes
 
-Role attributes are flags on the role itself that determine some of the core privileges it has on the database cluster level.  These can be set when the role is initially created, or changed at any time by any role with the appropriate attributes (`SUPERUSER` or `CREATEROLE` in this case).
+Role attributes are flags on the role itself that determine some of the core privileges it has on the database cluster level. These can be set when the role is initially created, or changed at any time by any role with the appropriate attributes (`SUPERUSER` or `CREATEROLE` in this case).
 
 Attributes that can be applied to a role include:
 
-* `LOGIN`: Allows users to initially connect to the database cluster using this role.  The `CREATE USER` command automatically adds this attribute, while `CREATE ROLE` command does not.
-* `SUPERUSER`: Allows the role to bypass all permission checks except the right to log in.  Only other `SUPERUSER` roles can create roles with this attribute.
-* `CREATEDB`: Allows the role to create new databases.
-* `CREATEROLE`: Allows the role to create, alter, and delete other roles.  This attribute also allows the role to assign or alter role membership.  An exception is that a role with the `CREATEROLE` attribute cannot alter `SUPERUSER` roles without also having the `SUPERUSER` attribute.
-* `REPLICATION`: Allows the role to initiate streaming replication.  Roles with this attribute must also have the `LOGIN` attribute.
-* `PASSWORD`: Assigns a password to the role that will be used with `password` or `md5` authentication mechanisms.  This attribute takes a password in quotations as an argument directly after the attribute keyword.
-* `INHERIT`: Determines whether the role inherits the privileges of roles it is a member of.  Without the `INHERIT`, members must use `SET ROLE` to change into the other role in order to access those exclusive privileges.  This attribute is set for new roles by default.
+- `LOGIN`: Allows users to initially connect to the database cluster using this role. The `CREATE USER` command automatically adds this attribute, while `CREATE ROLE` command does not.
+- `SUPERUSER`: Allows the role to bypass all permission checks except the right to log in. Only other `SUPERUSER` roles can create roles with this attribute.
+- `CREATEDB`: Allows the role to create new databases.
+- `CREATEROLE`: Allows the role to create, alter, and delete other roles. This attribute also allows the role to assign or alter role membership. An exception is that a role with the `CREATEROLE` attribute cannot alter `SUPERUSER` roles without also having the `SUPERUSER` attribute.
+- `REPLICATION`: Allows the role to initiate streaming replication. Roles with this attribute must also have the `LOGIN` attribute.
+- `PASSWORD`: Assigns a password to the role that will be used with `password` or `md5` authentication mechanisms. This attribute takes a password in quotations as an argument directly after the attribute keyword.
+- `INHERIT`: Determines whether the role inherits the privileges of roles it is a member of. Without the `INHERIT`, members must use `SET ROLE` to change into the other role in order to access those exclusive privileges. This attribute is set for new roles by default.
 
 You can find out more about role attributes by checking out PostgreSQL's documentation on [role attributes](https://www.postgresql.org/docs/current/role-attributes.html) and the [`CREATE ROLE` command](https://www.postgresql.org/docs/current/sql-createrole.html).
 
 ## What is a `superuser` role?
 
-As mentioned briefly above, a special privilege called `superuser` allows unrestricted administrative access to the database cluster.  This is similar to the `root` account in Linux and Unix-like operating systems, but at the database level.
+As mentioned briefly above, a special privilege called `superuser` allows unrestricted administrative access to the database cluster. This is similar to the `root` account in Linux and Unix-like operating systems, but at the database level.
 
-There must always be at least one role with `superuser` privileges in each database cluster.  The initial `superuser` account is created during the installation process.  The name of the initial `superuser` account can vary depending on the installation process, but most often, this account is called `postgres`.
+There must always be at least one role with `superuser` privileges in each database cluster. The initial `superuser` account is created during the installation process. The name of the initial `superuser` account can vary depending on the installation process, but most often, this account is called `postgres`.
 
-It is not recommended to do your day-to-day work using an account with `superuser` privileges, both because of its potential for destructive actions and also to minimize the chance of compromising an account with broad access.  Instead, most of the time, users should use accounts dedicated to the specific functions or data objects they are working with, only using the `superuser` accounts when more powerful access is required.
+It is not recommended to do your day-to-day work using an account with `superuser` privileges, both because of its potential for destructive actions and also to minimize the chance of compromising an account with broad access. Instead, most of the time, users should use accounts dedicated to the specific functions or data objects they are working with, only using the `superuser` accounts when more powerful access is required.
 
 ## Checking existing role attributes
 
-Now that you have a broad idea of what role attributes are and what types of privileges they allow, you should learn how to find the attributes applied to roles throughout PostgreSQL.  This section will show you some commands to help you find the attributes set on roles in general and on your own current role specifically.
+Now that you have a broad idea of what role attributes are and what types of privileges they allow, you should learn how to find the attributes applied to roles throughout PostgreSQL. This section will show you some commands to help you find the attributes set on roles in general and on your own current role specifically.
 
 ### Listing all database roles and their attributes
 
@@ -68,12 +69,13 @@ The `\du` meta-command shows all roles and their attributes:
 ```
 \du
 ```
+
 ```
                                    List of roles
  Role name |                         Attributes                         | Member of
 -----------+------------------------------------------------------------+-----------
  postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
- ```
+```
 
 In this case, the `postgres` role is the default role with `superuser` privileges configured for this database cluster.
 
@@ -94,7 +96,7 @@ WHERE r.rolname !~ '^pg_'
 ORDER BY 1;
 ```
 
-A similar query that provides role attribute information (without the role membership component) is below.  We use the `psql` meta-command `\x on` to output the results vertically for better readability here:
+A similar query that provides role attribute information (without the role membership component) is below. We use the `psql` meta-command `\x on` to output the results vertically for better readability here:
 
 ```sql
 -- turn on vertical display
@@ -103,6 +105,7 @@ SELECT * FROM pg_roles WHERE rolname !~ '^pg_';
 -- turn off vertical display
 \x off
 ```
+
 ```
 -[ RECORD 1 ]--+---------
 rolname        | postgres
@@ -114,9 +117,9 @@ rolcanlogin    | t
 rolreplication | t
 rolconnlimit   | -1
 rolpassword    | ********
-rolvaliduntil  | 
+rolvaliduntil  |
 rolbypassrls   | t
-rolconfig      | 
+rolconfig      |
 oid            | 10
 ```
 
@@ -125,6 +128,7 @@ If you are only interested in seeing which roles have the `superuser` attribute,
 ```sql
 SELECT rolname FROM pg_roles WHERE rolsuper;
 ```
+
 ```
  rolname
 ----------
@@ -137,6 +141,7 @@ Alternatively, you can list all users and their `superuser` status for a more co
 ```sql
 SELECT usename,usesuper FROM pg_user;
 ```
+
 ```
  usename  | usesuper
 ----------+----------
@@ -150,6 +155,7 @@ The same information can be retrieved using PostgreSQL's "role" paradigm instead
 ```sql
 SELECT rolname,rolsuper FROM pg_roles WHERE rolname !~ '^pg_';
 ```
+
 ```
  rolname  | rolsuper
 ----------+----------
@@ -162,11 +168,12 @@ SELECT rolname,rolsuper FROM pg_roles WHERE rolname !~ '^pg_';
 
 If you want to find the attributes of the role you are currently using, you can easily filter the output.
 
-When using `psql` meta-commands, you can use the `USER` variable, which will be substituted with the current connected role.  `psql` uses the colon (`:`) to interpolate variables:
+When using `psql` meta-commands, you can use the `USER` variable, which will be substituted with the current connected role. `psql` uses the colon (`:`) to interpolate variables:
 
 ```sql
 \du :USER
 ```
+
 ```
                                    List of roles
  Role name |                         Attributes                         | Member of
@@ -174,7 +181,7 @@ When using `psql` meta-commands, you can use the `USER` variable, which will be 
  postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 ```
 
-To get a listing showing the values of all possible role attributes, you can use a query comparing the role name to the value returned by [the `CURRENT_ROLE` PostgreSQL function](https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE).  Again, we're using vertical output for readability:
+To get a listing showing the values of all possible role attributes, you can use a query comparing the role name to the value returned by [the `CURRENT_ROLE` PostgreSQL function](https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-SESSION-TABLE). Again, we're using vertical output for readability:
 
 ```sql
 -- First, turn on vertical output
@@ -183,6 +190,7 @@ SELECT * FROM pg_roles WHERE rolename = CURRENT_ROLE;
 -- Change back to normal output
 \x off
 ```
+
 ```
 -[ RECORD 1 ]--+---------
 rolname        | postgres
@@ -205,6 +213,7 @@ To just check whether your current role has `superuser` privileges, you can type
 ```sql
 SHOW is_superuser;
 ```
+
 ```
  is_superuser
 --------------
@@ -221,6 +230,7 @@ To check which roles within the system have role management privileges, type:
 ```sql
 SELECT rolname as "Users who can manage roles" FROM pg_roles WHERE rolsuper OR rolcreaterole;
 ```
+
 ```
  Users who can manage roles
 ----------------------------
@@ -233,6 +243,7 @@ If you just want to know whether your current role has role management privilege
 ```sql
 SELECT 'Yes' AS "Can I manage roles?" FROM pg_roles WHERE rolname = :'USER' AND (rolsuper OR rolcreaterole);
 ```
+
 ```
  Can I manage roles?
 ---------------------
@@ -244,9 +255,9 @@ SELECT 'Yes' AS "Can I manage roles?" FROM pg_roles WHERE rolname = :'USER' AND 
 
 Once you've verified that you have role management privileges, you can begin making, modifying, or removing roles within PostgreSQL.
 
-One option to set role attributes is to declare them at the time that you create the role.  This allows you to set the initial conditions for the role, but you can still modify them afterwards if you want to change the role's level of access.  You can find more information about the [`CREATE ROLE` command](https://www.postgresql.org/docs/current/sql-createrole.html) that we'll be using to familiarize yourself with the basic syntax.
+One option to set role attributes is to declare them at the time that you create the role. This allows you to set the initial conditions for the role, but you can still modify them afterwards if you want to change the role's level of access. You can find more information about the [`CREATE ROLE` command](https://www.postgresql.org/docs/current/sql-createrole.html) that we'll be using to familiarize yourself with the basic syntax.
 
-One way of creating a role is from the command line.  PostgreSQL includes a [`createuser` command](https://www.postgresql.org/docs/current/app-createuser.html) that will create a role within the database cluster with `LOGIN` privileges.
+One way of creating a role is from the command line. PostgreSQL includes a [`createuser` command](https://www.postgresql.org/docs/current/app-createuser.html) that will create a role within the database cluster with `LOGIN` privileges.
 
 The general syntax is:
 
@@ -280,7 +291,7 @@ For example, to create a role named `user1` that can login with the password `se
 CREATE ROLE "user1" WITH LOGIN PASSWORD 'secretpassword';
 ```
 
-To instead create a role with `superuser` privileges (you must also be a `superuser` to successfully execute this command) that *cannot* login (user must use `SET ROLE` to change to this role), you could type:
+To instead create a role with `superuser` privileges (you must also be a `superuser` to successfully execute this command) that _cannot_ login (user must use `SET ROLE` to change to this role), you could type:
 
 ```sql
 CREATE ROLE "user2" WITH SUPERUSER;
@@ -288,12 +299,11 @@ CREATE ROLE "user2" WITH SUPERUSER;
 
 ## Changing existing roles
 
-To modify the attributes of existing roles, you can use the [`ALTER ROLE` command](https://www.postgresql.org/docs/current/sql-alterrole.html) instead.  As with role creation, your current role must also have either `superuser` or `CREATEROLE` privileges.  Users who do not have those privileges can only use the `ALTER ROLE` command to change their own password.
+To modify the attributes of existing roles, you can use the [`ALTER ROLE` command](https://www.postgresql.org/docs/current/sql-alterrole.html) instead. As with role creation, your current role must also have either `superuser` or `CREATEROLE` privileges. Users who do not have those privileges can only use the `ALTER ROLE` command to change their own password.
 
-Altering roles allows you to change the attributes assigned to a role after creation.  The same attributes mentioned in the role creation section can be used with the `ALTER ROLE` syntax.  One difference is that each attribute type can be negated by adding the `NO` prefix.  For example, to allow a role to login to the database cluster, you can give it the `LOGIN` attribute.  To remove that ability, you'd alter the role by specifying `NOLOGIN`.
+Altering roles allows you to change the attributes assigned to a role after creation. The same attributes mentioned in the role creation section can be used with the `ALTER ROLE` syntax. One difference is that each attribute type can be negated by adding the `NO` prefix. For example, to allow a role to login to the database cluster, you can give it the `LOGIN` attribute. To remove that ability, you'd alter the role by specifying `NOLOGIN`.
 
-The `ALTER ROLE` command only changes the attributes are those explicitly mentioned.  In other words, the `ALTER ROLE` command specifies *changes* to attributes, not a full set of new attributes.
-
+The `ALTER ROLE` command only changes the attributes are those explicitly mentioned. In other words, the `ALTER ROLE` command specifies _changes_ to attributes, not a full set of new attributes.
 
 To allow the `user2` role to login to the database cluster, you can type:
 
@@ -321,7 +331,7 @@ To change the password for a role, you can type the following (all roles should 
 ALTER ROLE <role> WITH PASSWORD '<password>';
 ```
 
-Although the above command works, if possible, it is a better idea to use the `psql` meta-command to change passwords.  The `psql` command automatically prompts for a password and encrypts it before sending it to the server.  This helps avoid leaking sensitive data in logs.
+Although the above command works, if possible, it is a better idea to use the `psql` meta-command to change passwords. The `psql` command automatically prompts for a password and encrypts it before sending it to the server. This helps avoid leaking sensitive data in logs.
 
 You can change a role's password with `psql` by typing the following
 
@@ -342,19 +352,19 @@ Keep in mind that you cannot rename your current session role.
 
 ## Deleting roles
 
-Deleting an existing role follows a similar pattern to the previous commands.  Again, you must have `CREATEROLE` or `superuser` privileges to execute these commands.
+Deleting an existing role follows a similar pattern to the previous commands. Again, you must have `CREATEROLE` or `superuser` privileges to execute these commands.
 
-One complicating factor is that roles *cannot* be removed if they are still referenced by objects within the database.  This means that you must delete or transfer ownership of any objects that the role owns.  Afterwards, you must also revoke any additional privileges the role has on database objects.
+One complicating factor is that roles _cannot_ be removed if they are still referenced by objects within the database. This means that you must delete or transfer ownership of any objects that the role owns. Afterwards, you must also revoke any additional privileges the role has on database objects.
 
-A detailed explanation of [how to appropriately reassign and drop privileges](https://dba.stackexchange.com/a/155356) is provided by [Erwin Brandstetter](https://dba.stackexchange.com/users/3684/erwin-brandstetter) on the Database Administrators Stack Exchange site.  This same process is used below.
+A detailed explanation of [how to appropriately reassign and drop privileges](https://dba.stackexchange.com/a/155356) is provided by [Erwin Brandstetter](https://dba.stackexchange.com/users/3684/erwin-brandstetter) on the Database Administrators Stack Exchange site. This same process is used below.
 
-First, you can reassign all of the role's owned objects using the `REASSIGNED OWNED` command.  For instance, if you're preparing to delete the `user2` role, you can assign its objects to the `postgres` role by typing:
+First, you can reassign all of the role's owned objects using the `REASSIGNED OWNED` command. For instance, if you're preparing to delete the `user2` role, you can assign its objects to the `postgres` role by typing:
 
 ```sql
 REASSIGN OWNED BY "user2" TO "postgres";
 ```
 
-Now the objects are owned by `postgres`, we can use the `DROP OWNED` command to revoke all of the other privileges we've been granted on objects.  This command also deletes any objects we own, but since we have just transferred them to the `postgres` role, the `user2` role no longer has any owned objects.  Because of this, the command will only revoke any of the role's additional privileges:
+Now the objects are owned by `postgres`, we can use the `DROP OWNED` command to revoke all of the other privileges we've been granted on objects. This command also deletes any objects we own, but since we have just transferred them to the `postgres` role, the `user2` role no longer has any owned objects. Because of this, the command will only revoke any of the role's additional privileges:
 
 ```sql
 DROP OWNED BY "user2";
@@ -370,11 +380,11 @@ DROP ROLE "user2";
 
 ## Logging in using `psql`
 
-Once you have a new role configured, and have [configured authentication details using the `pg_hba.conf` file](/postgresql/authentication-and-authorization/configuring-user-authentication), you can login to the database cluster using your new role.  The `psql` command line client provides an easy way to do this.
+Once you have a new role configured, and have [configured authentication details using the `pg_hba.conf` file](/postgresql/authentication-and-authorization/configuring-user-authentication), you can login to the database cluster using your new role. The `psql` command line client provides an easy way to do this.
 
-By default, `psql` assumes you want to connect using a role that matches your operating system username.  So if you are logged into your computer as `john`, `psql` will assume that you want to try to connect to the database using a role that's also called `john`.
+By default, `psql` assumes you want to connect using a role that matches your operating system username. So if you are logged into your computer as `john`, `psql` will assume that you want to try to connect to the database using a role that's also called `john`.
 
-To override this behavior, you can pass the `-U` or `--username=` option.  For example, if you want to login to a role called `kerry`, you can type:
+To override this behavior, you can pass the `-U` or `--username=` option. For example, if you want to login to a role called `kerry`, you can type:
 
 ```
 psql -U kerry
@@ -384,18 +394,19 @@ The success of the `psql` command will depend on the existence of the `kerry` ro
 
 ## Changing to a different role during a session
 
-Sometimes, you may want to temporarily adopt the privileges and identity of another role you have access to.  For instance, this is necessary if you want to gain the privileges of a role you are a member of if your current role does not have the `INHERIT` attribute.
+Sometimes, you may want to temporarily adopt the privileges and identity of another role you have access to. For instance, this is necessary if you want to gain the privileges of a role you are a member of if your current role does not have the `INHERIT` attribute.
 
 To understand how this works, you have to know the terminology PostgreSQL uses to categorize active roles:
 
-* **Session role**: A session role is the role you logged in with during your initial connection to the PostgreSQL database cluster.  It sets your initial privileges and determines your access to the system.  This role must have the `LOGIN` attribute.
-* **Current role**: By contrast, the current role is the role that you are currently acting as.  The privileges associated with the current role, whether set directly or inherited from other roles, determine the actions you are allowed to perform and the objects you have access to.
+- **Session role**: A session role is the role you logged in with during your initial connection to the PostgreSQL database cluster. It sets your initial privileges and determines your access to the system. This role must have the `LOGIN` attribute.
+- **Current role**: By contrast, the current role is the role that you are currently acting as. The privileges associated with the current role, whether set directly or inherited from other roles, determine the actions you are allowed to perform and the objects you have access to.
 
 You can view your session and current role values by typing:
 
 ```sql
 SELECT SESSION_USER, CURRENT_USER;
 ```
+
 ```
  current_user | session_user
 --------------+--------------
@@ -403,10 +414,10 @@ SELECT SESSION_USER, CURRENT_USER;
 (1 row)
 ```
 
-While the only way to change your session role is to start a new connection using a different role, you can change your current role using the [`SET ROLE` command](https://www.postgresql.org/docs/current/sql-set-role.html).  The `SET ROLE` command is used to temporarily act as a different role.  The command also optionally takes the following modifiers:
+While the only way to change your session role is to start a new connection using a different role, you can change your current role using the [`SET ROLE` command](https://www.postgresql.org/docs/current/sql-set-role.html). The `SET ROLE` command is used to temporarily act as a different role. The command also optionally takes the following modifiers:
 
-* **`SESSION`**: The default setting.  This causes the `SET ROLE` command to affect the entire database session.
-* **`LOCAL`**: This modifier will make the command change the role only for current transaction.
+- **`SESSION`**: The default setting. This causes the `SET ROLE` command to affect the entire database session.
+- **`LOCAL`**: This modifier will make the command change the role only for current transaction.
 
 To change the current role to the `user2` role (for the rest of the session), type:
 
@@ -419,6 +430,7 @@ If you check your session and current role values, you will see that the current
 ```sql
 SELECT SESSION_USER, CURRENT_USER;
 ```
+
 ```
  current_user | session_user
 --------------+--------------
@@ -442,7 +454,7 @@ RESET ROLE;
 
 ## Conclusion
 
-PostgreSQL's system of roles, role attributes, grants, and authentication create a flexible system that allows administrators to effectively manage permissions and database access.  This guide described what exactly roles are and how they encompass a broad range of use cases.  It also covered how to create, modify, and delete roles and manage the role attributes that determine their global capabilities.  Understanding how to manage these identities is necessary in order to secure your databases and provide usable access to your legitimate users.
+PostgreSQL's system of roles, role attributes, grants, and authentication create a flexible system that allows administrators to effectively manage permissions and database access. This guide described what exactly roles are and how they encompass a broad range of use cases. It also covered how to create, modify, and delete roles and manage the role attributes that determine their global capabilities. Understanding how to manage these identities is necessary in order to secure your databases and provide usable access to your legitimate users.
 
 ## FAQ
 
@@ -474,12 +486,14 @@ The basic syntax and result would look like:
 ```sql
 \du :USER
 ```
+
 ```sql
                                    List of roles
  Role name |                         Attributes                         | Member of
 -----------+------------------------------------------------------------+-----------
  postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
 ```
+
 </details>
 
 <details><summary>How can you check if you have grant user privileges in PostgreSQL?</summary>
@@ -515,6 +529,7 @@ The basic syntax looks like:
 ```sql
 CREATE ROLE <role>;
 ```
+
 And with attributes:
 
 ```sql

--- a/content/04-postgresql/07-authentication-and-authorization/03-configuring-user-authentication.mdx
+++ b/content/04-postgresql/07-authentication-and-authorization/03-configuring-user-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Configuring PostgreSQL user authentication'
-metaTitle: "Configuration | Authentication and authorization | PostgreSQL"
+metaTitle: 'Configuration | Authentication and authorization | PostgreSQL'
 metaDescription: "Managing authentication is one of the fundamental requirements of managing any database system.  In this guide, we'll show you how to configure PostgreSQL's authentication methods to allow different types of access."
 metaImage: '/social/generic-postgresql.png'
 authors: ['justinellingwood']
@@ -8,11 +8,11 @@ authors: ['justinellingwood']
 
 ## Introduction
 
-One of the first things you'll need to think about when working with a [PostgreSQL](/intro/database-glossary#postgresql) database is how to connect and interact with the database instance.  This requires coordination between the database client — the component you use to interact with the database, and the database server — the actual PostgreSQL instance that stores, organizes, and provides access to your data.
+One of the first things you'll need to think about when working with a [PostgreSQL](/intro/database-glossary#postgresql) database is how to connect and interact with the database instance. This requires coordination between the database client — the component you use to interact with the database, and the database server — the actual PostgreSQL instance that stores, organizes, and provides access to your data.
 
-To manage this successfully, you need to know how to configure a PostgreSQL instance to allow the type of access and [authentication](/intro/database-glossary#authentication) methods you require.  In this guide, we'll cover how to modify your database server's authentication mechanisms to match your environment's requirements.
+To manage this successfully, you need to know how to configure a PostgreSQL instance to allow the type of access and [authentication](/intro/database-glossary#authentication) methods you require. In this guide, we'll cover how to modify your database server's authentication mechanisms to match your environment's requirements.
 
-In a companion guide, we cover [how to connect to a PostgreSQL instance using a database client](/postgresql/connecting-to-postgresql-databases).  Consider reading both guides for a more complete picture of how authentication works in PostgreSQL.
+In a companion guide, we cover [how to connect to a PostgreSQL instance using a database client](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connecting-to-postgresql-databases). Consider reading both guides for a more complete picture of how authentication works in PostgreSQL.
 
 ## Understanding PostgreSQL's authentication file
 
@@ -20,11 +20,11 @@ If you want to modify the rules that dictate how users can authenticate to your 
 
 The specific file you need to modify is called `pg_hba.conf`.
 
-> Note that you will have to restart your PostgreSQL instance for any new authentication configuration to take effect.  Different operating systems will handle this in different ways.  In most Linux distributions, you can type `sudo systemctl restart postgresql`.  If you've installed PostgreSQL through `brew`, you can try typing `brew services restart postgresql`.  An alternative that might work on a broader set of systems is `pg_ctl restart`.
+> Note that you will have to restart your PostgreSQL instance for any new authentication configuration to take effect. Different operating systems will handle this in different ways. In most Linux distributions, you can type `sudo systemctl restart postgresql`. If you've installed PostgreSQL through `brew`, you can try typing `brew services restart postgresql`. An alternative that might work on a broader set of systems is `pg_ctl restart`.
 
 ### Finding the `pg_hba.conf` file
 
-To find the `pg_hba.conf` file on your server, you can look in the PostgreSQL configuration directory.  The specific location will depend on the operating system and PostgreSQL version you are using.
+To find the `pg_hba.conf` file on your server, you can look in the PostgreSQL configuration directory. The specific location will depend on the operating system and PostgreSQL version you are using.
 
 If you don't know where the authentication configuration file is, but you do have access to the database, you can query PostgreSQL for the file location, as [Craig Ringer demonstrates in this post](https://askubuntu.com/a/256711).
 
@@ -33,6 +33,7 @@ If you are on the command line, you can type the following, which queries for th
 ```bash
 psql -t -P format=unaligned -c 'SHOW hba_file;'
 ```
+
 ```
 /etc/postgresql/10/main/pg_hba.conf
 ```
@@ -42,6 +43,7 @@ If you already have a PostgreSQL session open, you can simply type:
 ```sql
 SHOW hba_file;
 ```
+
 ```
               hba_file
 -------------------------------------
@@ -59,7 +61,7 @@ By default, the file contains the current configuration as well as a number of h
 
 ### Understanding the `pg_hba.conf` file format
 
-The `pg_hba.conf` file uses a table-like structure implemented in plain text.  With blank lines and comments removed, a basic file might look something like this:
+The `pg_hba.conf` file uses a table-like structure implemented in plain text. With blank lines and comments removed, a basic file might look something like this:
 
 ```
 # TYPE    DATABASE    USER        ADDRESS         METHOD  OPTIONS
@@ -76,13 +78,15 @@ Let's take a look at the different fields mean and how the file's contents are i
 
 ### How the `pg_hba.conf` file is structured and interpreted
 
-Each line in the `pg_hba.conf` file describes a way for clients to authenticate to the system.  The majority of each line describes match conditions used to compare with incoming connection requests.  The final components specify an authentication method allowed and any options needed for authentication.
+Each line in the `pg_hba.conf` file describes a way for clients to authenticate to the system. The majority of each line describes match conditions used to compare with incoming connection requests. The final components specify an authentication method allowed and any options needed for authentication.
 
-When PostgreSQL evaluates connection requests against the authentication rules, it does so in sequence, from top to bottom.  If the configuration in a line matches the characteristics of the connection request, PostgreSQL will use the authentication information specified on the line to decide whether to authenticate the client.
+When PostgreSQL evaluates connection requests against the authentication rules, it does so in sequence, from top to bottom. If the configuration in a line matches the characteristics of the connection request, PostgreSQL will use the authentication information specified on the line to decide whether to authenticate the client.
 
-If the client successfully authenticates, a connection will be established.  If authentication is unsuccessful, the connection will be refused.   PostgreSQL does *not* continue processing to see if other rules match the request.  Because of this, the order of your rules is significant.
+If the client successfully authenticates, a connection will be established. If authentication is unsuccessful, the connection will be refused. PostgreSQL does _not_ continue processing to see if other rules match the request. Because of this, the order of your rules is significant.
 
-Within each line, fields are separated by white space — either spaces or tabs.  Although it is usually visually helpful to format these fields into columns, PostgreSQL does not require this.
+Within each line, fields are separated by white space — either spaces or tabs. Although it is usually visually helpful to format these fields into columns, PostgreSQL does not require this.
+
+<PostgresCallout />
 
 ## What each field in the `pg_hba.conf` file means
 
@@ -90,104 +94,104 @@ Now that you understand a bit about how the file is structured and interpreted, 
 
 The fields we'll cover are:
 
-* Connection type
-* Database
-* Username
-* Address
-* Method of authentication
-* Options for the authentication method
+- Connection type
+- Database
+- Username
+- Address
+- Method of authentication
+- Options for the authentication method
 
 ### Connection type
 
-The first field in each record specifies the type of connection request to match.  Only connections that use the specified connection will match each rule.
+The first field in each record specifies the type of connection request to match. Only connections that use the specified connection will match each rule.
 
 The connection type must be one of the following:
 
-* **`local`**: Records with `local` match connections made over a local Unix domain socket file instead of over a network.  Local connections are preferred when possible for security and performance reasons.
-* **`host`**: Lines that begin with `host` match any connection request made over the network.  This is a general catch-all for network connections.  More granular matching is available with the following types.
-* **`hostssl`**: The `hostssl` connection type matches any connections that are made over the network with TLS/SSL encryption.  This is usually the best connection type to use when allowing external connections.
-* **`hostnossl`**: The `hostnossl` type matches any network connection that is not secured by TLS/SSL.
+- **`local`**: Records with `local` match connections made over a local Unix domain socket file instead of over a network. Local connections are preferred when possible for security and performance reasons.
+- **`host`**: Lines that begin with `host` match any connection request made over the network. This is a general catch-all for network connections. More granular matching is available with the following types.
+- **`hostssl`**: The `hostssl` connection type matches any connections that are made over the network with TLS/SSL encryption. This is usually the best connection type to use when allowing external connections.
+- **`hostnossl`**: The `hostnossl` type matches any network connection that is not secured by TLS/SSL.
 
 Starting with PostgreSQL 12, support has been added for [GSSAPI connections](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=b0b39f72b9904bcb80f97b35837ccff1578aa4b8&utm_source=anzwix) as well, introducing these additional options:
 
-* **`hostgssenc`**: The `hostgssenc` connection type matches any network connection that uses [GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) encryption.  This option only makes sense for those who already use GSSAPI ifor security.
-* **`hostnogssenc`**: The `hostnogssen` type matches every network connection that doesn't use GSSAPI encryption.
+- **`hostgssenc`**: The `hostgssenc` connection type matches any network connection that uses [GSSAPI](https://en.wikipedia.org/wiki/Generic_Security_Services_Application_Program_Interface) encryption. This option only makes sense for those who already use GSSAPI ifor security.
+- **`hostnogssenc`**: The `hostnogssen` type matches every network connection that doesn't use GSSAPI encryption.
 
 ### Database
 
-The next field specifies the database that the request is attempting to access.  The database specified in the connection request must satisfy the value found in this column for the line to match.
+The next field specifies the database that the request is attempting to access. The database specified in the connection request must satisfy the value found in this column for the line to match.
 
 The values can be any of the following:
 
-* **`all`**:  A database value of `all` is a catch all value that matches any database requested.  This is useful if you don't want the current match rule to evaluate the database value.
-* **`sameuser`**: The `sameuser` value matches connections where the requested database and username are the same.
-* **`samerole`**: The `samerole` database value will match a connection if the user specified is a member of a *role* with the same name as the requested database.
-* **`replication`**: Using a value of `replication` will match any incoming connection used for database replication.  Connections used for replication to not provide a database target, so this matches replication requests instead.
-* **[specific database name]**: You can also provide one or more specific database names to match.  These will only match connections if they request one of the listed databases.  You can separate multiple database names with a comma or specify a file to read names from by preceding the filename with an `@` symbol.
+- **`all`**: A database value of `all` is a catch all value that matches any database requested. This is useful if you don't want the current match rule to evaluate the database value.
+- **`sameuser`**: The `sameuser` value matches connections where the requested database and username are the same.
+- **`samerole`**: The `samerole` database value will match a connection if the user specified is a member of a _role_ with the same name as the requested database.
+- **`replication`**: Using a value of `replication` will match any incoming connection used for database replication. Connections used for replication to not provide a database target, so this matches replication requests instead.
+- **[specific database name]**: You can also provide one or more specific database names to match. These will only match connections if they request one of the listed databases. You can separate multiple database names with a comma or specify a file to read names from by preceding the filename with an `@` symbol.
 
 ### User
 
-The next field is used to match against the user provided by the connection request.  The connection's user value must satisfy the rule's user field to match the rule.
+The next field is used to match against the user provided by the connection request. The connection's user value must satisfy the rule's user field to match the rule.
 
 The user field can take these options:
 
-* **`all`**: A value of `all` tells PostgreSQL that any value in the connection's user parameter satisfies this rule's user requirements.
-* **[specific user or group name]**: The only other option for the user field is to provide a specific user, a list of users, or a group.  Multiple users can be specified by separating the values with a comma.  If a name begins with a `+` symbol, it is interpreted as a group name rather than a user name.  In this case, the rule will match if the requested user is a member of the group the rule specifies.  Again, you can tell PostgreSQL to read values from a file instead of providing them inline by instead providing a filename preceded by the `@` symbol.
+- **`all`**: A value of `all` tells PostgreSQL that any value in the connection's user parameter satisfies this rule's user requirements.
+- **[specific user or group name]**: The only other option for the user field is to provide a specific user, a list of users, or a group. Multiple users can be specified by separating the values with a comma. If a name begins with a `+` symbol, it is interpreted as a group name rather than a user name. In this case, the rule will match if the requested user is a member of the group the rule specifies. Again, you can tell PostgreSQL to read values from a file instead of providing them inline by instead providing a filename preceded by the `@` symbol.
 
 ### Address
 
-For all connection types that begin with `host` (`host`, `hostssl`, and `hostnossl`, as well as `hostgssenc` and `hostnogssenc` in PostgreSQL 12 and later), an address field comes next.  For `local` connections, this field is skipped.
+For all connection types that begin with `host` (`host`, `hostssl`, and `hostnossl`, as well as `hostgssenc` and `hostnogssenc` in PostgreSQL 12 and later), an address field comes next. For `local` connections, this field is skipped.
 
-The address field specifies the *client* machine's addresses or patterns to match against the connection's address.  This means that the connection is evaluated according to where it is originating.  The connection's origin must satisfy the rule's address value for the rule to match.
+The address field specifies the _client_ machine's addresses or patterns to match against the connection's address. This means that the connection is evaluated according to where it is originating. The connection's origin must satisfy the rule's address value for the rule to match.
 
 The address field can be filled out with any of these:
 
-* **`all`**: An address value of `all` tells PostgreSQL that any client address will satisfy this condition.
-* **`samehost`**: The value `samehost` is used to indicate that any networked connections originating from one of the server's own IP addresses should match.
-* **`samenet`**: The `samenet` value indicates that any IP address from the server's network subnets will match.
-* **[CIDR IP address range]**: You can also supply an IP address range using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).  This can specify a single IP address (using a `/32` subnet for IPv4 addresses or a `/128` subnet for IPv6 addresses) or a range of addresses by providing a more expansive CIDR mask.  IP address ranges will only match client connections made from within the specified range using the IP protocol specified.
-* **[host name]**: A host name can also be specified directly.  In this case, the client's host name will be evaluated using a forward and reverse DNS query to ensure it resolves as expected.  If the specified hostname starts with a dot, any host that resolves correctly on that domain will satisfy the requirements.
+- **`all`**: An address value of `all` tells PostgreSQL that any client address will satisfy this condition.
+- **`samehost`**: The value `samehost` is used to indicate that any networked connections originating from one of the server's own IP addresses should match.
+- **`samenet`**: The `samenet` value indicates that any IP address from the server's network subnets will match.
+- **[CIDR IP address range]**: You can also supply an IP address range using [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation). This can specify a single IP address (using a `/32` subnet for IPv4 addresses or a `/128` subnet for IPv6 addresses) or a range of addresses by providing a more expansive CIDR mask. IP address ranges will only match client connections made from within the specified range using the IP protocol specified.
+- **[host name]**: A host name can also be specified directly. In this case, the client's host name will be evaluated using a forward and reverse DNS query to ensure it resolves as expected. If the specified hostname starts with a dot, any host that resolves correctly on that domain will satisfy the requirements.
 
 ### Authentication method
 
-If a connection satisfies all of the previous match criteria, the given authentication method is then applied.  This is the next field in each line.
+If a connection satisfies all of the previous match criteria, the given authentication method is then applied. This is the next field in each line.
 
-The authentication method is the way that PostgreSQL decides whether to accept connections that match the rule.  It can be set to any of the following choices:
+The authentication method is the way that PostgreSQL decides whether to accept connections that match the rule. It can be set to any of the following choices:
 
-* **`trust`**: A value of `trust` immediately accepts the connection without further requirements.  This assumes that other external authentication methods are in place.  It is not recommended in most cases.
-* **`reject`**: A value of `reject` immediately rejects the connection.  This is mainly used to filter out connections that match unwanted patterns.
-* **`scram-sha-256`**: The `scram-sha-256` method will check the password provided by the user using [`SCRAM-SHA-256` authentication](https://tools.ietf.org/html/rfc7677).  If all of your clients support it, this is currently the most secure option for password authentication.
-* **`md5`**: The `md5` method also checks user passwords.  This method is less secure than `scram-sha-256` but more widely supported.  The current implementation will automatically use `scram-sha-256` even if `md5` is specified if the password is encrypted with SCRAM.
-* **`password`**: The `password` method is the least secure password authentication method.  It sends passwords in plain text and should not be used unless the connection uses TLS/SSL to encrypt the entire connection.
-* **`gss`**: The `gss` method uses GSSAPI for authentication.  This can be used for authentication regardless of whether GSSAPI encryption is used for the connection.  This allows authenticating through Kerberos and similar software.
-* **`sspi`**: The `sspi` method uses the Windows-only Security Support Provider Interface API to authenticate clients.
-* **`ident`**: The `ident` method checks with a client's ident server for the user initiating the connection.  Since this relies on the client's machine, it should only be used for trusted networks where the client machines are tightly controlled.
-* **`peer`**: The `peer` authentication method is used for local connections.  It asks the local operating system for the client's system username.  It checks if the name matches the requested database name.
-* **`ldap`**: The `ldap` method authenticates by using an [LDAP server](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) to validate usernames and passwords.
-* **`radius`**: Select `radius` to use a [RADIUS server](https://en.wikipedia.org/wiki/RADIUS) to check username and password combinations.
-* **`cert`**: The `cert` method authenticates clients using TLS/SSL client certificates.  This is only available for TLS/SSL connections.  The client certificate must be a valid, trusted certificate to be accepted.
-* **`pam`**: The `pam` option will defer authentication to the operating system's [PAM service](https://en.wikipedia.org/wiki/Pluggable_authentication_module).
-* **`bsd`**: The `bsd` method uses the [BSD Authentication service](https://en.wikipedia.org/wiki/BSD_Authentication) to validate usernames and passwords.  This method is only available on OpenBSD hosts.
+- **`trust`**: A value of `trust` immediately accepts the connection without further requirements. This assumes that other external authentication methods are in place. It is not recommended in most cases.
+- **`reject`**: A value of `reject` immediately rejects the connection. This is mainly used to filter out connections that match unwanted patterns.
+- **`scram-sha-256`**: The `scram-sha-256` method will check the password provided by the user using [`SCRAM-SHA-256` authentication](https://tools.ietf.org/html/rfc7677). If all of your clients support it, this is currently the most secure option for password authentication.
+- **`md5`**: The `md5` method also checks user passwords. This method is less secure than `scram-sha-256` but more widely supported. The current implementation will automatically use `scram-sha-256` even if `md5` is specified if the password is encrypted with SCRAM.
+- **`password`**: The `password` method is the least secure password authentication method. It sends passwords in plain text and should not be used unless the connection uses TLS/SSL to encrypt the entire connection.
+- **`gss`**: The `gss` method uses GSSAPI for authentication. This can be used for authentication regardless of whether GSSAPI encryption is used for the connection. This allows authenticating through Kerberos and similar software.
+- **`sspi`**: The `sspi` method uses the Windows-only Security Support Provider Interface API to authenticate clients.
+- **`ident`**: The `ident` method checks with a client's ident server for the user initiating the connection. Since this relies on the client's machine, it should only be used for trusted networks where the client machines are tightly controlled.
+- **`peer`**: The `peer` authentication method is used for local connections. It asks the local operating system for the client's system username. It checks if the name matches the requested database name.
+- **`ldap`**: The `ldap` method authenticates by using an [LDAP server](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) to validate usernames and passwords.
+- **`radius`**: Select `radius` to use a [RADIUS server](https://en.wikipedia.org/wiki/RADIUS) to check username and password combinations.
+- **`cert`**: The `cert` method authenticates clients using TLS/SSL client certificates. This is only available for TLS/SSL connections. The client certificate must be a valid, trusted certificate to be accepted.
+- **`pam`**: The `pam` option will defer authentication to the operating system's [PAM service](https://en.wikipedia.org/wiki/Pluggable_authentication_module).
+- **`bsd`**: The `bsd` method uses the [BSD Authentication service](https://en.wikipedia.org/wiki/BSD_Authentication) to validate usernames and passwords. This method is only available on OpenBSD hosts.
 
-Some of the methods above are only applicable to certain types of connections or with additional pieces of infrastructure in place.  For most deployments, `reject`, `peer`, and `scram-sha-256` or `md5` are sufficient to start with additional methods, like `ldap` available depending on your infrastructure.
+Some of the methods above are only applicable to certain types of connections or with additional pieces of infrastructure in place. For most deployments, `reject`, `peer`, and `scram-sha-256` or `md5` are sufficient to start with additional methods, like `ldap` available depending on your infrastructure.
 
 ### Authentication options
 
-After the authentication method, a final, optional column may be present to provide additional options for the authentication method.  The use of this column is largely dependent on the type of authentication method selected.
+After the authentication method, a final, optional column may be present to provide additional options for the authentication method. The use of this column is largely dependent on the type of authentication method selected.
 
-For authentication methods that reference external servers, these options often specify the host and connection information so that PostgreSQL can successfully query the authentication service.  Another option that is common to quite a few authentication methods is a `map` parameter that allows you to translate between system and PostgreSQL database usernames.
+For authentication methods that reference external servers, these options often specify the host and connection information so that PostgreSQL can successfully query the authentication service. Another option that is common to quite a few authentication methods is a `map` parameter that allows you to translate between system and PostgreSQL database usernames.
 
-Each authentication method has its own set of valid options.  Be sure to check the applicable options on the page for each method in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/client-authentication.html).
+Each authentication method has its own set of valid options. Be sure to check the applicable options on the page for each method in the [PostgreSQL documentation](https://www.postgresql.org/docs/current/client-authentication.html).
 
 ## Configuring common authentication policies
 
-We've introduced some of the main authentication options, but how do you use these to implement reasonable policies?  In this section, we'll cover how to configure some of the most common authentication policies.
+We've introduced some of the main authentication options, but how do you use these to implement reasonable policies? In this section, we'll cover how to configure some of the most common authentication policies.
 
 ### Allow local users to connect to matching databases
 
-It is common to configure PostgreSQL to allow users on the same machine machine to authenticate to the same PostgreSQL username.  For example, using `peer` authentication, an operating system user named `john` would be able to log in automatically without a password if PostgreSQL also has a username named `john`.
+It is common to configure PostgreSQL to allow users on the same machine machine to authenticate to the same PostgreSQL username. For example, using `peer` authentication, an operating system user named `john` would be able to log in automatically without a password if PostgreSQL also has a username named `john`.
 
-This will work for any local connections made using the PostgreSQL socket file.  If you specify any network address, even if it is the `127.0.0.1` local loopback device, the connection will not use the socket and will not match the `peer` authentication line.  Connections to `localhost`, however, will use the socket file and will match these lines.
+This will work for any local connections made using the PostgreSQL socket file. If you specify any network address, even if it is the `127.0.0.1` local loopback device, the connection will not use the socket and will not match the `peer` authentication line. Connections to `localhost`, however, will use the socket file and will match these lines.
 
 To allow all PostgreSQL users to authenticate from a matching operating system user, add a line that matches the `local` connection type, allows all databases and usernames, and uses `peer` authentication:
 
@@ -203,7 +207,7 @@ If you want to limit this so that only the `john` and `sue` PostgreSQL users can
 local     all         john,sue                    peer
 ```
 
-If you need allow an operating system user named `sue` to authenticate to a database user named `susan`, you can specify a `map` option at the end of the line.  Choose a map name to identify this mapping:
+If you need allow an operating system user named `sue` to authenticate to a database user named `susan`, you can specify a `map` option at the end of the line. Choose a map name to identify this mapping:
 
 ```
 # TYPE    DATABASE    USER        ADDRESS         METHOD  OPTIONS
@@ -227,13 +231,13 @@ Now, the `sue` operating system will be able to authenticate to the `susan` Post
 
 ### Allow network connections from the same machine using passwords
 
-To authenticate network connections from the PostgreSQL server's machine (non-socket connections) using passwords, you need to match a `host` connection type instead of `local`.  You can then limit the acceptable addresses to the local loopback devices and allow users to authenticate using `md5` or `scram-sha-256`.
+To authenticate network connections from the PostgreSQL server's machine (non-socket connections) using passwords, you need to match a `host` connection type instead of `local`. You can then limit the acceptable addresses to the local loopback devices and allow users to authenticate using `md5` or `scram-sha-256`.
 
 For instance, if a user on the machine that PostgreSQL is hosted on tries to connect by specifying `127.0.0.1` as the host, PostgreSQL can perform password authentication.
 
-To set this up, we need to use the `host` connection type.  Next, we need to specify the range of acceptable addresses.  Since this rule should only match local connections, we'll specify the local loopback device.  We will have to add two separate lines to match the IPv4 and IPv6 loopback devices.
+To set this up, we need to use the `host` connection type. Next, we need to specify the range of acceptable addresses. Since this rule should only match local connections, we'll specify the local loopback device. We will have to add two separate lines to match the IPv4 and IPv6 loopback devices.
 
-Afterwards, you can specify the password scheme you want to use for authentication.  The `scram-sha-256` method is more secure, but the `md5` method is more widely supported.
+Afterwards, you can specify the password scheme you want to use for authentication. The `scram-sha-256` method is more secure, but the `md5` method is more widely supported.
 
 The finished authentication lines will look something like this:
 
@@ -247,9 +251,9 @@ You can limit the databases or users that are allowed to authenticate using this
 
 ### Allow automatic maintenance
 
-An assortment of automated maintenance tasks are performed on a regular basis.  To ensure that these operations can authenticate and run as expected, you need to ensure that a administrative account is capable of authenticating non-interactively.
+An assortment of automated maintenance tasks are performed on a regular basis. To ensure that these operations can authenticate and run as expected, you need to ensure that a administrative account is capable of authenticating non-interactively.
 
-By default, the `postgres` account is configured for this role using `peer` authentication.  This line is very likely already present in your `pg_hba.conf` file:
+By default, the `postgres` account is configured for this role using `peer` authentication. This line is very likely already present in your `pg_hba.conf` file:
 
 ```
 # TYPE    DATABASE    USER        ADDRESS         METHOD  OPTIONS
@@ -260,9 +264,9 @@ Ensure that this or a similar line is present in your file, especially if you ar
 
 ### Allow connections used for replication
 
-Replication is a special processes that copies data from one database to another, usually on a frequent basis.  Unlike other types of connections, replication connections do not specify a specific database they want to connect to.
+Replication is a special processes that copies data from one database to another, usually on a frequent basis. Unlike other types of connections, replication connections do not specify a specific database they want to connect to.
 
-The `replication` keyword in the database column is used to match these replication connections.  Any user with the [replication privilege](https://www.postgresql.org/docs/current/sql-createrole.html) is able to establish a replication connection.
+The `replication` keyword in the database column is used to match these replication connections. Any user with the [replication privilege](https://www.postgresql.org/docs/current/sql-createrole.html) is able to establish a replication connection.
 
 To allow for all local replication connections, in a way that mirrors our previous values for regular connections (`peer` for connections over the Unix socket and `md5` for connections over the local network), we can add the following lines:
 
@@ -273,7 +277,7 @@ host      replication all         127.0.0.1/32    md5
 host      replication all         ::1/128         md5
 ```
 
-To allow replication from additional locations, you can add additional addresses.  For example, to allow replication from any machines on the local `192.0.2.0/24` network, you can add a line that looks like this:
+To allow replication from additional locations, you can add additional addresses. For example, to allow replication from any machines on the local `192.0.2.0/24` network, you can add a line that looks like this:
 
 ```
 # TYPE    DATABASE    USER        ADDRESS         METHOD  OPTIONS
@@ -284,7 +288,7 @@ This will allow any replication connections coming from machines within that net
 
 ### Allow connections from local network using passwords
 
-Above, we demonstrated how to configure password authentication for local replication connections.  This can be generalized to allow password authentication for any local network connections.
+Above, we demonstrated how to configure password authentication for local replication connections. This can be generalized to allow password authentication for any local network connections.
 
 To allow `md5` password authentication for any connections coming from the local `192.0.2.0/24` network, you can add a line like this:
 
@@ -297,7 +301,7 @@ This will allow all hosts within the `192.0.2.0/24` network to authenticate to P
 
 ### Allow remote connections using SSL and passwords
 
-To allow connections from outside of a trusted network, you should always tunnel the connection through secure encryption, like TLS/SSL.  If you need to allow these connections, you should match against the `hostssl` connection type.
+To allow connections from outside of a trusted network, you should always tunnel the connection through secure encryption, like TLS/SSL. If you need to allow these connections, you should match against the `hostssl` connection type.
 
 For example, to allow password authentication from anywhere that can connect to the database server, but only if TLS/SSL is used, you can add a line like this to your authentication file:
 
@@ -306,13 +310,13 @@ For example, to allow password authentication from anywhere that can connect to 
 hostssl   all         all         all             md5
 ```
 
-This will allow any external connections using TLS/SSL to authenticate using `md5`-encrypted passwords.  You can easily limit the access by specifying more restrictive addresses.
+This will allow any external connections using TLS/SSL to authenticate using `md5`-encrypted passwords. You can easily limit the access by specifying more restrictive addresses.
 
-If you use the `hostssl` connection type, you will have to configure SSL for your PostgreSQL instance.  You will have to generate or otherwise obtain an SSL certificate, an SSL key, and an SSL root certificate and then modify the `postgresql.conf` configuration file, as specified in the [PostgreSQL documentation on configuring SSL](https://www.postgresql.org/docs/current/ssl-tcp.html).
+If you use the `hostssl` connection type, you will have to configure SSL for your PostgreSQL instance. You will have to generate or otherwise obtain an SSL certificate, an SSL key, and an SSL root certificate and then modify the `postgresql.conf` configuration file, as specified in the [PostgreSQL documentation on configuring SSL](https://www.postgresql.org/docs/current/ssl-tcp.html).
 
 ### Allow remote connections using SSL and SSL client certificates
 
-If you are already forcing SSL for external connections, you may want to consider using SSL client certificates for authentication instead of passwords.  This will allow clients to present their client SSL certificate.  The server checks that it is valid and signed by a trusted certificate authority.  If so, it will allow authentication according to the rules provided.
+If you are already forcing SSL for external connections, you may want to consider using SSL client certificates for authentication instead of passwords. This will allow clients to present their client SSL certificate. The server checks that it is valid and signed by a trusted certificate authority. If so, it will allow authentication according to the rules provided.
 
 To set up SSL client authentication, we can use a similar line to the one we used before:
 
@@ -321,9 +325,9 @@ To set up SSL client authentication, we can use a similar line to the one we use
 hostssl   all         all         all             cert
 ```
 
-With this configuration, the server will not prompt users for passwords, but will instead require a valid SSL certificate.  The certificate's common name (CN) field must match the database user that is being requested, or else be configured with a `map` file.
+With this configuration, the server will not prompt users for passwords, but will instead require a valid SSL certificate. The certificate's common name (CN) field must match the database user that is being requested, or else be configured with a `map` file.
 
-For instance, for a certificate with a CN of `katherine` to authenticate to a PostgreSQL user named `kate`, you'd need to specify a  map file in the `pg_hba.conf` file:
+For instance, for a certificate with a CN of `katherine` to authenticate to a PostgreSQL user named `kate`, you'd need to specify a map file in the `pg_hba.conf` file:
 
 ```
 # TYPE    DATABASE    USER        ADDRESS         METHOD  OPTIONS
@@ -335,6 +339,7 @@ Afterwards, you'd edit the `pg_ident.conf` file to explicitly map those two user
 ```bash
 vim pg_ident.conf
 ```
+
 ```
 # MAPNAME       SYSTEM-USERNAME         PG-USERNAME
 my-map-name     katherine               kate
@@ -344,6 +349,6 @@ You can learn how to create and configure client certificates in [PostgreSQL's d
 
 ## Conclusion
 
-In this guide, we covered PostgreSQL authentication from the server side.  We demonstrated how to modify a PostgreSQL instance's configuration to change how clients are allowed to authenticate.  After discussing the different options available in the authentication file, we covered how to implement some common authentication strategies using what we learned earlier.
+In this guide, we covered PostgreSQL authentication from the server side. We demonstrated how to modify a PostgreSQL instance's configuration to change how clients are allowed to authenticate. After discussing the different options available in the authentication file, we covered how to implement some common authentication strategies using what we learned earlier.
 
-Knowing how to configure authentication, combined with [an understanding of how to connect with a PostgreSQL client](/postgresql/connecting-to-postgresql-databases), allow you to grant access to legitimate clients while guarding against unwanted connections.  This configuration is an important part of securing your database instances and preventing disruptive login problems that might hinder your operations.
+Knowing how to configure authentication, combined with [an understanding of how to connect with a PostgreSQL client](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connecting-to-postgresql-databases), allow you to grant access to legitimate clients while guarding against unwanted connections. This configuration is an important part of securing your database instances and preventing disruptive login problems that might hinder your operations.

--- a/content/04-postgresql/07-authentication-and-authorization/04-managing-privileges.mdx
+++ b/content/04-postgresql/07-authentication-and-authorization/04-managing-privileges.mdx
@@ -8,58 +8,60 @@ authors: ['justinellingwood']
 
 ## Introduction
 
-Controlling what each user is allowed to do within your database is an important part of administrating a database cluster.  [PostgreSQL](/intro/database-glossary#postgresql) provides a suite of tools to control [authentication](/intro/database-glossary#authentication) and [authorization](/intro/database-glossary#authorization).
+Controlling what each user is allowed to do within your database is an important part of administrating a database cluster. [PostgreSQL](/intro/database-glossary#postgresql) provides a suite of tools to control [authentication](/intro/database-glossary#authentication) and [authorization](/intro/database-glossary#authorization).
 
-On the authentication front, the [`pg_hba.conf` file controls how people can connect to the database](/postgresql/authentication-and-authorization/configuring-user-authentication).  This includes the exact user, database, connection method, and authentication method combinations that are allowed access to the server.  The authorization component starts with PostgreSQL's concept of [roles and role attributes](/postgresql/authentication-and-authorization/role-management) which defines the user entities within the system and controls their global privileges.
+On the authentication front, the [`pg_hba.conf` file controls how people can connect to the database](/postgresql/authentication-and-authorization/configuring-user-authentication). This includes the exact user, database, connection method, and authentication method combinations that are allowed access to the server. The authorization component starts with PostgreSQL's concept of [roles and role attributes](/postgresql/authentication-and-authorization/role-management) which defines the user entities within the system and controls their global privileges.
 
-A further level of authorization is present beyond those offered by role attributes.  Managing ownership and grants on specific database objects is the primary way to control which roles can manage, modify, and view databases, tables, sequences, and more.  This guide will cover how to use PostgreSQL's grant and revocation mechanisms to lay out exactly what roles have access to each database object.
+A further level of authorization is present beyond those offered by role attributes. Managing ownership and grants on specific database objects is the primary way to control which roles can manage, modify, and view databases, tables, sequences, and more. This guide will cover how to use PostgreSQL's grant and revocation mechanisms to lay out exactly what roles have access to each database object.
 
 ## What are PostgreSQL object privileges?
 
-In the article on [roles and role attributes](/postgresql/authentication-and-authorization/role-management), the concept of defining system-wide privileges for roles was introduced.  Using role attributes, administrators can define whether roles can create or modify databases, manage roles, or even login to the system itself.  These types of privileges are hold true across the entire database cluster, so they offer no granularity when it comes to controlling access to individual objects within the database.
+In the article on [roles and role attributes](/postgresql/authentication-and-authorization/role-management), the concept of defining system-wide privileges for roles was introduced. Using role attributes, administrators can define whether roles can create or modify databases, manage roles, or even login to the system itself. These types of privileges are hold true across the entire database cluster, so they offer no granularity when it comes to controlling access to individual objects within the database.
 
-Instead, PostgreSQL uses a complimentary system of individual grants or rights on specific database entities.  This allows the owners of database objects to determine what types of actions are permitted by which roles.  This additional flexibility and granularity is what makes multi-user and multitenant deployments both possible and practical.
+Instead, PostgreSQL uses a complimentary system of individual grants or rights on specific database entities. This allows the owners of database objects to determine what types of actions are permitted by which roles. This additional flexibility and granularity is what makes multi-user and multitenant deployments both possible and practical.
 
-Database *grants* or *privileges* define the specific set of operations or levels of access available for various authenticated roles.  PostgreSQL's grant system follows an "allow list" model, meaning that roles are given no access to database objects except for those explicitly granted.
+Database _grants_ or _privileges_ define the specific set of operations or levels of access available for various authenticated roles. PostgreSQL's grant system follows an "allow list" model, meaning that roles are given no access to database objects except for those explicitly granted.
+
+<PostgresCallout />
 
 ## How do object ownership and role membership affect object privileges?
 
-Fundamental to this system are the concepts of object ownership and role membership.  In PostgreSQL, every database object has exactly one *owner* who alone, along with `superuser` roles, has the unique ability to alter, delete, and manage the object itself.  The object owner manages the privileges on the object for other roles by granting privileges.  Every privilege granted on a database object can ultimately be controlled by the object owner.
+Fundamental to this system are the concepts of object ownership and role membership. In PostgreSQL, every database object has exactly one _owner_ who alone, along with `superuser` roles, has the unique ability to alter, delete, and manage the object itself. The object owner manages the privileges on the object for other roles by granting privileges. Every privilege granted on a database object can ultimately be controlled by the object owner.
 
-Role membership is a system that gives roles the privileges of the roles they are members of.  Roles with the `INHERIT` attribute that are members of other roles gain access to their privileges automatically, without having to [use `SET ROLE` to change the current role](/postgresql/authentication-and-authorization/role-management#changing-to-a-different-role-during-a-session).
+Role membership is a system that gives roles the privileges of the roles they are members of. Roles with the `INHERIT` attribute that are members of other roles gain access to their privileges automatically, without having to [use `SET ROLE` to change the current role](/postgresql/authentication-and-authorization/role-management#changing-to-a-different-role-during-a-session).
 
-For example, imagine a `salesadmin` role with the ability to modify data within the `sales` database.  If the `sally` role has the `INHERIT` role attribute set, then adding `sally` to the `salesadmin` role will automatically enable `sally` to modify data in the `sales` database.  The ability to inherit characteristics enables a flexible style of access management by grouping attributes and access by "functional" roles and then adding actual "user" roles to those functional roles as required.
+For example, imagine a `salesadmin` role with the ability to modify data within the `sales` database. If the `sally` role has the `INHERIT` role attribute set, then adding `sally` to the `salesadmin` role will automatically enable `sally` to modify data in the `sales` database. The ability to inherit characteristics enables a flexible style of access management by grouping attributes and access by "functional" roles and then adding actual "user" roles to those functional roles as required.
 
-Every role on the system is a member of the `PUBLIC` role by default.  This makes it synonymous with "everyone" when defining privileges.
+Every role on the system is a member of the `PUBLIC` role by default. This makes it synonymous with "everyone" when defining privileges.
 
 ## An overview of available object privileges
 
 PostgreSQL has a number of privileges that can be given to roles to enable specific functionality.
 
-Privileges are applicable only on a subset of database objects where they make sense.  For instance, it would not make sense to "execute" a database.  For guidance on which privileges are valid with which database objects, refer to the [ACL Privileges Abbreviations table](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE) and the [Summary of Access Privileges table](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGES-SUMMARY-TABLE) from the PostgreSQL documentation.
+Privileges are applicable only on a subset of database objects where they make sense. For instance, it would not make sense to "execute" a database. For guidance on which privileges are valid with which database objects, refer to the [ACL Privileges Abbreviations table](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE) and the [Summary of Access Privileges table](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGES-SUMMARY-TABLE) from the PostgreSQL documentation.
 
-Below is a list of each privilege name and its function.  You can find a [full explanation of each privilege in the PostgreSQL documentation](https://www.postgresql.org/docs/current/ddl-priv.html).
+Below is a list of each privilege name and its function. You can find a [full explanation of each privilege in the PostgreSQL documentation](https://www.postgresql.org/docs/current/ddl-priv.html).
 
-* `SELECT`: The `SELECT` privilege gives a role the ability to select, or read, from a database object.  This privilege is also necessary for any `UPDATE` and `DELETE` operations that reference existing column values.
-* `INSERT`: Provides the ability to add a new row of data to a table, [view](/intro/database-glossary#view), or column.
-* `UPDATE`: Gives the ability to update the values stored for columns in a database object.  The `SELECT` privilege will also be required for most `UPDATE` operations.
-* `DELETE`: Lets a role delete a row from a table or view.  Like `UPDATE`, most `DELETE` operations require the `SELECT` privilege as well in order to target the correct rows.
-* `TRUNCATE`: The `TRUNCATE` privilege allows a role empty a table or view of all data.
-* `REFERENCES`: Provides roles with the ability to create [foreign keys](/intro/database-glossary#foreign-key) referencing a table or table column.
-* `TRIGGER`: Lets a role define a trigger on a table or view.
-* `CREATE`: Allows roles to create child entities of databases, schemas, or tablespaces.  For example, on databases the `CREATE` privilege allows the role to create new schemas, while on schemas it allows the role to create new databases.
-* `CONNECT`: Lets the role connect to a database.  This is checked at connection time.
-* `TEMPORARY`: Allows the role to create temporary tables within a database.
-* `EXECUTE`: Gives the role permission to call functions or [procedures](/intro/database-glossary#stored-procedure).
-* `USAGE`: Allows roles basic functionality on objects.  For instance, `USAGE` on schemas allows the role look up objects within it, while `USAGE` on sequences allows the role to call the `currval` and `nextval` functions.
-* `ALL PRIVILEGES`: A shorthand giving the role in question all privileges on the specified object.
+- `SELECT`: The `SELECT` privilege gives a role the ability to select, or read, from a database object. This privilege is also necessary for any `UPDATE` and `DELETE` operations that reference existing column values.
+- `INSERT`: Provides the ability to add a new row of data to a table, [view](/intro/database-glossary#view), or column.
+- `UPDATE`: Gives the ability to update the values stored for columns in a database object. The `SELECT` privilege will also be required for most `UPDATE` operations.
+- `DELETE`: Lets a role delete a row from a table or view. Like `UPDATE`, most `DELETE` operations require the `SELECT` privilege as well in order to target the correct rows.
+- `TRUNCATE`: The `TRUNCATE` privilege allows a role empty a table or view of all data.
+- `REFERENCES`: Provides roles with the ability to create [foreign keys](/intro/database-glossary#foreign-key) referencing a table or table column.
+- `TRIGGER`: Lets a role define a trigger on a table or view.
+- `CREATE`: Allows roles to create child entities of databases, schemas, or tablespaces. For example, on databases the `CREATE` privilege allows the role to create new schemas, while on schemas it allows the role to create new databases.
+- `CONNECT`: Lets the role connect to a database. This is checked at connection time.
+- `TEMPORARY`: Allows the role to create temporary tables within a database.
+- `EXECUTE`: Gives the role permission to call functions or [procedures](/intro/database-glossary#stored-procedure).
+- `USAGE`: Allows roles basic functionality on objects. For instance, `USAGE` on schemas allows the role look up objects within it, while `USAGE` on sequences allows the role to call the `currval` and `nextval` functions.
+- `ALL PRIVILEGES`: A shorthand giving the role in question all privileges on the specified object.
 
 ## Using the `GRANT` command
 
 The `GRANT` command is used for two separate but related purposes in role management:
 
-* Granting specific privileges on database objects to a role
-* Adding roles as members of other roles
+- Granting specific privileges on database objects to a role
+- Adding roles as members of other roles
 
 These two functions are reflected in the two structures found in the command syntax.
 
@@ -69,17 +71,17 @@ To grant privileges on a specific database object to a given role, use following
 GRANT <privilege> ON <database_object> TO <role> [WITH GRANT OPTION];
 ```
 
-The optional `WITH GRANT OPTION` clause additionally gives the receiving role the ability to pass on this capability to other roles.  For instance, if `adam` is granted the ability to `DELETE` data from `customers` with the `WITH GRANT OPTION`, he can, in turn, optionally grant that capability to `delores`.  Practically speaking, this gives you the ability to let roles administer certain capabilities on specific objects.
+The optional `WITH GRANT OPTION` clause additionally gives the receiving role the ability to pass on this capability to other roles. For instance, if `adam` is granted the ability to `DELETE` data from `customers` with the `WITH GRANT OPTION`, he can, in turn, optionally grant that capability to `delores`. Practically speaking, this gives you the ability to let roles administer certain capabilities on specific objects.
 
-The other syntax, used to add a role to another role, looks like this.  In this context, the `<role_member>` is given the privileges of the `<provider_role>`:
+The other syntax, used to add a role to another role, looks like this. In this context, the `<role_member>` is given the privileges of the `<provider_role>`:
 
 ```sql
 GRANT <provider_role> TO <role_member> [WITH ADMIN OPTION];
 ```
 
-If the `<role_member>` has the `INHERIT` attribute set, it will immediately have access to the privileges of the `<provider_role>`.  If this attribute is missing, the `<role_member>` can access the privileges of the `<provider_role>` by changing the current role with [`SET ROLE`](/postgresql/authentication-and-authorization/role-management#changing-to-a-different-role-during-a-session).
+If the `<role_member>` has the `INHERIT` attribute set, it will immediately have access to the privileges of the `<provider_role>`. If this attribute is missing, the `<role_member>` can access the privileges of the `<provider_role>` by changing the current role with [`SET ROLE`](/postgresql/authentication-and-authorization/role-management#changing-to-a-different-role-during-a-session).
 
-Similar to the `WITH GRANT OPTION` clause in the other syntax, when granting membership to a role, you can optionally add a `WITH ADMIN OPTION` clause.  This clause additionally gives the role member the ability to add new members.
+Similar to the `WITH GRANT OPTION` clause in the other syntax, when granting membership to a role, you can optionally add a `WITH ADMIN OPTION` clause. This clause additionally gives the role member the ability to add new members.
 
 ### Examples
 
@@ -121,7 +123,7 @@ GRANT "salesperson" TO "sofie" WITH ADMIN OPTION;
 
 ## Using the `REVOKE` command
 
-The `REVOKE` command revokes privileges from roles on a database object.  For the most part, it mirrors the syntax of the `GRANT` command, with two formats to cover the two use cases.
+The `REVOKE` command revokes privileges from roles on a database object. For the most part, it mirrors the syntax of the `GRANT` command, with two formats to cover the two use cases.
 
 To revoke a specific privilege on a database object from a given role, use the following format:
 
@@ -129,11 +131,11 @@ To revoke a specific privilege on a database object from a given role, use the f
 REVOKE [GRANT OPTION FOR] <privilege> ON <database_object> FROM <role> [CASCADE | RESTRICT];
 ```
 
-In this case, the optional `GRANT OPTION FOR` clause can be added to remove the ability for the specified role to pass on the given privilege.  A conflict can occur when attempting to revoke the `GRANT OPTION` from a role who has already passed on the privilege to another role.  In that case, removing the `GRANT OPTION` from the first role would break the chain of grants that gives the secondary role their privileges.
+In this case, the optional `GRANT OPTION FOR` clause can be added to remove the ability for the specified role to pass on the given privilege. A conflict can occur when attempting to revoke the `GRANT OPTION` from a role who has already passed on the privilege to another role. In that case, removing the `GRANT OPTION` from the first role would break the chain of grants that gives the secondary role their privileges.
 
-For example, if `ada` has granted the ability to update content on a `records` database to `pete` using `WITH GRANT OPTION`, `pete` could then give the ability to update content to `simone`.  If `ada` revokes the `GRANT OPTION` from `pete`, it is unclear what should happen to the update privilege passed on to `simone`.
+For example, if `ada` has granted the ability to update content on a `records` database to `pete` using `WITH GRANT OPTION`, `pete` could then give the ability to update content to `simone`. If `ada` revokes the `GRANT OPTION` from `pete`, it is unclear what should happen to the update privilege passed on to `simone`.
 
-The optional `CASCADE` or `RESTRICT` clauses resolve this conflict by specifying explicitly what `REVOKE` should do in this scenario.  The default behavior is `RESTRICT`, which will cause the `REVOKE GRANT OPTION FOR` command to fail if a privilege has been passed on to another role.  The `CASCADE` option changes this behavior to revoke the privilege from any "downstream" roles in addition to the specified role, resolving the conflict by removing the broken chain.
+The optional `CASCADE` or `RESTRICT` clauses resolve this conflict by specifying explicitly what `REVOKE` should do in this scenario. The default behavior is `RESTRICT`, which will cause the `REVOKE GRANT OPTION FOR` command to fail if a privilege has been passed on to another role. The `CASCADE` option changes this behavior to revoke the privilege from any "downstream" roles in addition to the specified role, resolving the conflict by removing the broken chain.
 
 The other syntax, used to revoke role membership, looks like this:
 
@@ -157,7 +159,7 @@ Remove all access to `finances` from `jerry`:
 REVOKE ALL PRIVILEGES ON "finances" FROM "jerry";
 ```
 
-Remove the ability for `alice` to grant the `DELETE` privilege to other roles on the `snacks` table.  Keep in mind that `alice` will still have the `DELETE` privilege following this command, but will no longer be able to pass that privilege on:
+Remove the ability for `alice` to grant the `DELETE` privilege to other roles on the `snacks` table. Keep in mind that `alice` will still have the `DELETE` privilege following this command, but will no longer be able to pass that privilege on:
 
 ```sql
 REVOKE GRANT OPTION FOR DELETE ON "snacks" FROM "alice";
@@ -169,7 +171,7 @@ Remove `natasha` from the `moderators` role:
 REVOKE "moderators" FROM "natasha";
 ```
 
-Revoke the ability to administer membership for the `hr` role from `tony`.  Keep in mind that `tony` will still be a member of `hr`:
+Revoke the ability to administer membership for the `hr` role from `tony`. Keep in mind that `tony` will still be a member of `hr`:
 
 ```sql
 REVOKE ADMIN OPTION FOR "hr" FROM "tony";
@@ -177,6 +179,6 @@ REVOKE ADMIN OPTION FOR "hr" FROM "tony";
 
 ## Conclusion
 
-PostgreSQL's grant and privilege system allows you to define granular privileges to individual roles on specific database objects.  The grant system extends PostgreSQL's authorization controls down to individual objects that can be managed by their owners.
+PostgreSQL's grant and privilege system allows you to define granular privileges to individual roles on specific database objects. The grant system extends PostgreSQL's authorization controls down to individual objects that can be managed by their owners.
 
-This arrangement allows individual users to exercise control over their own database objects.  They can grant and revoke access, as well as delegate certain management functions to other roles.  In addition, the same arrangement is used to implement role membership in order to simplify privilege management.
+This arrangement allows individual users to exercise control over their own database objects. They can grant and revoke access, as well as delegate certain management functions to other roles. In addition, the same arrangement is used to implement role membership in order to simplify privilege management.

--- a/content/04-postgresql/08-create-and-delete-databases-and-tables.mdx
+++ b/content/04-postgresql/08-create-and-delete-databases-and-tables.mdx
@@ -32,7 +32,7 @@ In PostgreSQL, there is also an intermediary object between databases and tables
 
 This guide won't deal directly with PostgreSQL's concept of a schema, but it's good to know it's there.
 
-Instead, we'll be focusing on how to create and destroy PostgreSQL databases and tables. The examples will primarily use SQL, but [towards the end](#using-administrative-command-line-tools-to-create-and-delete-databases), we'll show you how to do a few of these tasks using the [command line](https://www.prisma.io/dataguide/postgresql/connecting-to-postgresql-databases). These alternatives use tools included in the standard PostgreSQL installation that are available if you have administrative access to the PostgreSQL host.
+Instead, we'll be focusing on how to create and destroy PostgreSQL databases and tables. The examples will primarily use SQL, but [towards the end](#using-administrative-command-line-tools-to-create-and-delete-databases), we'll show you how to do a few of these tasks using the [command line](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connecting-to-postgresql-databases). These alternatives use tools included in the standard PostgreSQL installation that are available if you have administrative access to the PostgreSQL host.
 
 Some of the statements covered in this guide, particularly the PostgreSQL `CREATE TABLE` statement, have many additional options that were outside of the scope of this article. If you'd like additional information, find out more by checking out the [official PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createtable.html).
 
@@ -54,6 +54,8 @@ Specifically, your PostgreSQL user will need the `CREATE DB` privilege or be a `
 ```
 
 The `postgres` superuser, which is created automatically upon installation, has the required privileges, but you can use any user with the `Create DB` privilege.
+
+<PostgresCallout />
 
 ## Create a new database
 
@@ -152,7 +154,7 @@ The `school` database that we created is displayed among the other databases on 
 
 ## Create tables within databases
 
-After creating one or more databases, you can begin to define tables to store your data. Tables consist of a name and a defined schema which determines the fields and [data types](/postgresql/introduction-to-data-types) that each record must contain.
+After creating one or more databases, you can begin to define tables to store your data. Tables consist of a name and a defined schema which determines the fields and [data types](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/introduction-to-data-types) that each record must contain.
 
 ### PostgreSQL `CREATE TABLE` syntax
 
@@ -168,7 +170,7 @@ CREATE TABLE table_name (
 The components of the above syntax include the following:
 
 - **`CREATE TABLE table_name`**: The basic creation statement that signals that you wish to define a table. The `table_name` placeholder should be replaced with the name of the table you wish to use.
-- **`column_name TYPE`**: Defines a basic column within the table. The `column_name` placeholder should be replaced with the name you wish to use for your column. The `TYPE` specifies the [PostgreSQL data type](/postgresql/introduction-to-data-types) for the column. Data stored within the table must conform to the column structure and column data types to be accepted.
+- **`column_name TYPE`**: Defines a basic column within the table. The `column_name` placeholder should be replaced with the name you wish to use for your column. The `TYPE` specifies the [PostgreSQL data type](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/introduction-to-data-types) for the column. Data stored within the table must conform to the column structure and column data types to be accepted.
 - **`column_constraint`**: [Column constraints](/postgresql/column-and-table-constraints#column-constraints) are optional restraints to add further restrictions on the data that can be stored in the column. For example, you can require that entries be not null, unique, or positive integers.
 - **`table_constraints`**: [Table constraints](/postgresql/column-and-table-constraints#table-constraints) are similar to column constraints but involve the interaction of multiple columns. For instance, you could have a table constraint that checks that a `DATE_OF_BIRTH` is before `DATE_OF_DEATH` in a table.
 

--- a/content/04-postgresql/09-introduction-to-data-types.mdx
+++ b/content/04-postgresql/09-introduction-to-data-types.mdx
@@ -171,6 +171,8 @@ Because of the dependency on locale settings of the PostgreSQL installation or e
 
 Care must also be taken when casting values in and out of the `money` type since it can lose precision data when converting between certain types. It is safe for `money` values to cast to and from the `numeric` type (used for arbitrary precision, as shown above), so it is recommended to always use `numeric` as an intermediary before performing converting to other types.
 
+<PostgresCallout />
+
 ## Text and characters
 
 PostgreSQL's character types and string types can be placed into two categories: _fixed length_ and _variable length_. The choice between these two affects how PostgreSQL allocates space for each value and how it validates input.

--- a/content/04-postgresql/10-column-and-table-constraints.mdx
+++ b/content/04-postgresql/10-column-and-table-constraints.mdx
@@ -8,7 +8,7 @@ authors: ['justinellingwood']
 
 ## What are PostgreSQL column and table constraints?
 
-[Constraints](/intro/database-glossary#constraint) are _additional_ requirements for acceptable values in addition to those provided by [data types](/postgresql/introduction-to-data-types). They allow you to define narrower conditions for your data than those found in the general purpose data types.
+[Constraints](/intro/database-glossary#constraint) are _additional_ requirements for acceptable values in addition to those provided by [data types](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/introduction-to-data-types). They allow you to define narrower conditions for your data than those found in the general purpose data types.
 
 These are often reflections on the specific characteristics of a field based on additional context provided by your applications. For example, an `age` field might use the `int` data type to store whole numbers. However, certain ranges of acceptable integers do not make sense as valid ages. For instance, negative integers would not be reasonable in this scenario. We can express this logical requirement in PostgreSQL using constraints.
 
@@ -78,6 +78,8 @@ CREATE TABLE qualified_borrowers (
 Here, we use the `CHECK` constraint again to check that the `account_number` is not null and that the loan officer has marked the client as having acceptable collateral by checking the `acceptable_collateral` column. A table constraint is necessary since multiple columns are being checked.
 
 Now is a good time to mention that although we'll mainly be using the `CREATE TABLE` SQL command in these examples to create a new table, you can also add constraints to an existing table with [`ALTER TABLE`](https://www.postgresql.org/docs/current/sql-altertable.html). When using `ALTER TABLE`, by default, new constraints cause the values currently in the table to be checked against the new constraint. You can skip this behavior by including the `NOT VALID` clause.
+
+<PostgresCallout />
 
 ## Creating names for constraints
 

--- a/content/04-postgresql/11-date-types.mdx
+++ b/content/04-postgresql/11-date-types.mdx
@@ -14,7 +14,7 @@ In this guide, we are going to discuss storing `DATE` types in PostgreSQL and th
 
 ## PostgreSQL `DATE` data type
 
-The [`DATE` type in PostgreSQL](https://www.prisma.io/dataguide/postgresql/introduction-to-data-types#dates-and-time) can store a date without an associated time value:
+The [`DATE` type in PostgreSQL](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/introduction-to-data-types#dates-and-time) can store a date without an associated time value:
 
 ```sql
 DATE
@@ -53,6 +53,8 @@ SELECT * FROM checkouts;
          1 | James Joyce |   Ulysses  |   1922-02-02   |  2021-09-27
 (1 row)
 ```
+
+<PostgresCallout />
 
 ## PostgreSQL `DATE` functions
 

--- a/content/04-postgresql/12-inserting-and-modifying-data/01-inserting-and-deleting-data.mdx
+++ b/content/04-postgresql/12-inserting-and-modifying-data/01-inserting-and-deleting-data.mdx
@@ -61,6 +61,8 @@ FROM information_schema.columns WHERE table_name ='employee';
 
 These should give you a good idea of the table's structure so that you can insert values correctly.
 
+<PostgresCallout />
+
 ## Using `INSERT` to add new records to tables
 
 The SQL `INSERT` command is used to add rows of data to an existing table. Once you know the table's structure, you can construct a command that matches the table's columns with the corresponding values you wish to insert for the new record.

--- a/content/04-postgresql/12-inserting-and-modifying-data/02-updating-existing-data.mdx
+++ b/content/04-postgresql/12-inserting-and-modifying-data/02-updating-existing-data.mdx
@@ -166,6 +166,8 @@ SELECT * FROM director;
 (3 rows)
 ```
 
+<PostgresCallout />
+
 ## Conclusion
 
 In this guide, we've taken a look at the basic ways that you can modify existing data within a table using the `UPDATE` command. Using these basic concepts, you can specify the exact criteria necessary to identify the existing rows within a table, update column names with new values, and optionally return the rows that were impacted. The `UPDATE` command is essential for managing your data after its initial ingestion into your databases.

--- a/content/04-postgresql/12-inserting-and-modifying-data/03-insert-on-conflict.mdx
+++ b/content/04-postgresql/12-inserting-and-modifying-data/03-insert-on-conflict.mdx
@@ -40,6 +40,8 @@ When `DO UPDATE` is specified, a special virtual table called `EXCLUDED` is avai
 
 **Note:** If you are connecting to your database with [Prisma Client](https://www.prisma.io/docs/orm/prisma-client), you can perform upsert operations using the dedicated [upsert operation](https://www.prisma.io/docs/orm/prisma-client/queries/crud#upsert).
 
+<PostgresCallout />
+
 ## Using the `DO NOTHING` action
 
 For our examples, suppose that we have a table called `director`.

--- a/content/04-postgresql/12-inserting-and-modifying-data/04-importing-and-exporting-data-in-postgresql.mdx
+++ b/content/04-postgresql/12-inserting-and-modifying-data/04-importing-and-exporting-data-in-postgresql.mdx
@@ -8,7 +8,7 @@ authors: ['justinellingwood']
 
 ## Overview
 
-This guide describes how you can export data from and import data into a PostgreSQL database.  You can learn more about this topic in the official [PostgreSQL docs](https://www.postgresql.org/docs/current/backup-dump.html).
+This guide describes how you can export data from and import data into a PostgreSQL database. You can learn more about this topic in the official [PostgreSQL docs](https://www.postgresql.org/docs/current/backup-dump.html).
 
 ## Data export with `pg_dump`
 
@@ -20,8 +20,8 @@ pg_dump --help
 
 From the [PostgreSQL docs](https://www.postgresql.org/docs/current/backup-dump.html):
 
-> The idea behind this dump method is to generate a file with SQL commands that, when fed back to the server, will recreate the database in the same state as it was at the time of the dump.  PostgreSQL provides the utility program `pg_dump` for this purpose.
-> `pg_dump` is a regular PostgreSQL client application (albeit a particularly clever one).  This means that you can perform this backup procedure from any remote host that has access to the database.  But remember that `pg_dump` does not operate with special permissions.  In particular, it must have read access to all tables that you want to back up, so in order to back up the entire database you almost always have to run it as a database superuser.
+> The idea behind this dump method is to generate a file with SQL commands that, when fed back to the server, will recreate the database in the same state as it was at the time of the dump. PostgreSQL provides the utility program `pg_dump` for this purpose.
+> `pg_dump` is a regular PostgreSQL client application (albeit a particularly clever one). This means that you can perform this backup procedure from any remote host that has access to the database. But remember that `pg_dump` does not operate with special permissions. In particular, it must have read access to all tables that you want to back up, so in order to back up the entire database you almost always have to run it as a database superuser.
 
 The basic syntax of the command looks like this:
 
@@ -31,8 +31,8 @@ pg_dump DB_NAME > OUTPUT_FILE
 
 You need to replace the `DB_NAME` and `OUTPUT_FILE` placeholders with the respective values for:
 
-* your **database name**
-* the name of the desired **output file** (should end in `.sql` for best interoperability)
+- your **database name**
+- the name of the desired **output file** (should end in `.sql` for best interoperability)
 
 For example, to export data from a database called `mydb` on a local PostgreSQL server into a file called `mydb.sql`, you can use the following command:
 
@@ -45,6 +45,8 @@ If your database schema uses [Object Identifier Types](https://www.postgresql.or
 ```shell
 pg_dump mydb --oids > mydb.sql
 ```
+
+<PostgresCallout />
 
 ## Providing database credentials
 
@@ -61,7 +63,7 @@ To authenticate against the PostgreSQL database server, you can use the followin
 | -------------------------- | ----------------------------------------- | -------- | ------------------------------ |
 | `--username` (short: `-U`) | _your current operating system user name_ | `PGUSER` | The name of the database user. |
 
-For example, if you want to export data from a PostgreSQL database that has the following [connection string](/postgresql/short-guides/connection-uris):
+For example, if you want to export data from a PostgreSQL database that has the following [connection string](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris):
 
 ```
 postgresql://opnmyfngbknppm:XXX@ec2-46-137-91-216.eu-west-1.compute.amazonaws.com:5432/d50rgmkqi2ipus
@@ -79,22 +81,22 @@ Note that **this command will trigger a prompt where you need to specify the pas
 
 There might be cases where you don't want to dump the _entire_ database, for example you might want to:
 
-* dump only the actual data but exclude the [DDL](/intro/database-glossary#data-definition-language) (i.e. the SQL statements that define your database schema like `CREATE TABLE`,...)
-* dump only the DDL but exclude the actual data
-* exclude a specific PostgreSQL schema
-* exclude large files
-* exclude specific tables
+- dump only the actual data but exclude the [DDL](/intro/database-glossary#data-definition-language) (i.e. the SQL statements that define your database schema like `CREATE TABLE`,...)
+- dump only the DDL but exclude the actual data
+- exclude a specific PostgreSQL schema
+- exclude large files
+- exclude specific tables
 
 Here's an overview of a few command line options you can use in these scenarios:
 
-| Argument                        | Default                                                                             | Description                                                                                      |
-| ------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `--data-only` (short: `-a`)     | `false`                                                                             | Exclude any [DDL](https://www.postgresql.org/docs/current/ddl.html) statements and export only data. |
-| `--schema-only` (short: `-s`)   | `false`                                                                             | Exclude data and export only [DDL](https://www.postgresql.org/docs/current/ddl.html) statements.     |
-| `--blobs` (short: `-b`)         | `true` unless the `-schema`, `--table`, or `--schema-only` options are specified | Include binary large objects.                                                                    |
-| `--no-blobs` (short: `-B`)      | `false`                                                                             | Exclude binary large objects.                                                                    |
-| `--table` (short: `-t`)         | _includes all tables by default_                                                    | Explicitly specify the names of the tables to be dumped.                                         |
-| `--exclude-table` (short: `-T`) | -                                                                                   | Exclude specific tables from the dump.                                                           |
+| Argument                        | Default                                                                          | Description                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--data-only` (short: `-a`)     | `false`                                                                          | Exclude any [DDL](https://www.postgresql.org/docs/current/ddl.html) statements and export only data. |
+| `--schema-only` (short: `-s`)   | `false`                                                                          | Exclude data and export only [DDL](https://www.postgresql.org/docs/current/ddl.html) statements.     |
+| `--blobs` (short: `-b`)         | `true` unless the `-schema`, `--table`, or `--schema-only` options are specified | Include binary large objects.                                                                        |
+| `--no-blobs` (short: `-B`)      | `false`                                                                          | Exclude binary large objects.                                                                        |
+| `--table` (short: `-t`)         | _includes all tables by default_                                                 | Explicitly specify the names of the tables to be dumped.                                             |
+| `--exclude-table` (short: `-T`) | -                                                                                | Exclude specific tables from the dump.                                                               |
 
 ## Importing data from SQL files
 
@@ -106,8 +108,8 @@ psql DB_NAME < INPUT_FILE
 
 You need to replace the `DB_NAME` and `INPUT_FILE` placeholders with the respective values for:
 
-* your **database name** (a database with that name must be created beforehand!)
-* the name of the target **input file** (likely ends with `.sql`)
+- your **database name** (a database with that name must be created beforehand!)
+- the name of the target **input file** (likely ends with `.sql`)
 
 To create the database `DB_NAME` beforehand, you can use the [`template0`](https://www.postgresql.org/docs/current/manage-ag-templatedbs.html) (which creates a plain user database that doesn't contain any site-local additions):
 
@@ -117,4 +119,4 @@ CREATE DATABASE dbname TEMPLATE template0;
 
 ## Conclusion
 
-Exporting data from PostgreSQL and ingesting it again to recreate your data structures and populate databases is a good way to migrate data, back up and recover, or prepare for replication.  Understanding how the `pg_dump` and `psql` tools work together to accomplish this task will help you transfer data across the boundaries of your databases.
+Exporting data from PostgreSQL and ingesting it again to recreate your data structures and populate databases is a good way to migrate data, back up and recover, or prepare for replication. Understanding how the `pg_dump` and `psql` tools work together to accomplish this task will help you transfer data across the boundaries of your databases.

--- a/content/04-postgresql/12-inserting-and-modifying-data/05-using-transactions.mdx
+++ b/content/04-postgresql/12-inserting-and-modifying-data/05-using-transactions.mdx
@@ -22,6 +22,8 @@ These features help databases achieve [ACID compliance](/intro/database-glossary
 
 To achieve these goals, transactions employ a number of different strategies and different database systems use different methods. PostgreSQL uses a system called [Multiversion Concurrency Control (MVCC)](/intro/database-glossary#multiversion-concurrency-control), which allows the database to perform these actions without unnecessary locking using data snapshots. All together, these systems comprise one of the fundamental building blocks of modern relational databases, allowing them to safely process complex data in a crash-resistant manner.
 
+<PostgresCallout />
+
 ## Types of consistency failures
 
 One reason people use transactions is to gain certain guarantees about the consistency of their data and the environment in which it is processed. Consistency can be broken in many different ways, which affects how databases attempt to prevent them.

--- a/content/04-postgresql/13-reading-and-querying-data/01-basic-select.mdx
+++ b/content/04-postgresql/13-reading-and-querying-data/01-basic-select.mdx
@@ -275,6 +275,8 @@ You can filter duplicate rows from your query with Prisma Client by using the [d
 
 </PrismaOutlinks>
 
+<PostgresCallout />
+
 ## Conclusion
 
 In this guide, we covered some of the basic ways you can use the `SELECT` command to identify and display records from your tables and views. The `SELECT` command is one of the most flexible and powerful operations within SQL-oriented databases, with many different ways to add clauses, conditions, and filtering.

--- a/content/04-postgresql/13-reading-and-querying-data/02-filtering-data.mdx
+++ b/content/04-postgresql/13-reading-and-querying-data/02-filtering-data.mdx
@@ -107,6 +107,8 @@ Here, we can display any `customer` entries that have social security numbers th
 SELECT * FROM customer WHERE LENGTH(SSN) <> 9;
 ```
 
+<PostgresCallout />
+
 ## Using the `GROUP BY` clause to summarize multiple records
 
 The `GROUP BY` clause is another very common way to filter results by representing multiple results with a single row. The basic syntax of the `GROUP BY` clause looks like this:
@@ -439,6 +441,6 @@ PostgreSQL's `array_agg()` is a [user-defined aggregate function](https://www.po
 
 Yes, you can `GROUP BY` a timestamp value in PostgreSQL. However, this value includes a time element that would need timestamps to be identical to the millisecond to get grouped together.
 
-Grouping timestamps together by day, month, or year is best accomplished by casting the timestamp value into [PosgreSQL's `DATE` data type](https://www.prisma.io/dataguide/postgresql/date-types#postgresql-date-data-type) which has no associated time value.
+Grouping timestamps together by day, month, or year is best accomplished by casting the timestamp value into [PosgreSQL's `DATE` data type](https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/date-types#postgresql-date-data-type) which has no associated time value.
 
 </details>

--- a/content/04-postgresql/13-reading-and-querying-data/03-joining-tables.mdx
+++ b/content/04-postgresql/13-reading-and-querying-data/03-joining-tables.mdx
@@ -35,6 +35,8 @@ The type of join and the join conditions determine how each row that is displaye
 
 For the sake of convenience, many joins match the primary key on one table with an associated foreign key on the second table. Although primary and foreign keys are only used by the database system to maintain consistency guarantees, their relationship often makes them a good candidate for join conditions.
 
+<PostgresCallout />
+
 ## Different types of joins
 
 Various types of joins are available, each of which will potentially produce different results. Understanding how each type is constructed will help you determine which is appropriate for different scenarios.

--- a/content/04-postgresql/13-reading-and-querying-data/04-optimizing-postgresql.mdx
+++ b/content/04-postgresql/13-reading-and-querying-data/04-optimizing-postgresql.mdx
@@ -234,6 +234,8 @@ AND query wait_event != ''
 
 This can help you see queries that are not currently progressing because of other parts of the system (for instance, lock contention).
 
+<PostgresCallout />
+
 ## Check other system statistics
 
 While the `pg_stat_activity` view will probably provide most of the information you need to identify slower queries, it can be useful to look at other system statistics as well to help identify additional targets for optimization.

--- a/content/04-postgresql/14-short-guides/01-quoting-rules.mdx
+++ b/content/04-postgresql/14-short-guides/01-quoting-rules.mdx
@@ -42,6 +42,8 @@ However, keep in mind that this can lead to usability issues if not used careful
 
 Use double quotes sparingly for better compatibility, especially when creating objects. If you want to use double quotes, keep in mind that the case problem does not arise if you use double quotes with fully lower-cased identifiers.
 
+<PostgresCallout />
+
 ## Single quotes
 
 Single quotes, on the other hand, are used to indicate that a token is a string. This is used in many different contexts throughout PostgreSQL.

--- a/content/04-postgresql/14-short-guides/02-creating-deleting-users.mdx
+++ b/content/04-postgresql/14-short-guides/02-creating-deleting-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'How to create and delete users in PostgreSQL'
-metaTitle: "How to create and delete users in PostgreSQL"
-metaDescription: "This short guide will cover how to create and delete users in PostgreSQL."
+metaTitle: 'How to create and delete users in PostgreSQL'
+metaDescription: 'This short guide will cover how to create and delete users in PostgreSQL.'
 metaImage: '/social/generic-postgresql.png'
 authors: ['alexemerich']
 ---
@@ -11,7 +11,6 @@ authors: ['alexemerich']
 More often than not, when working with a database you will need to be able to create and delete users. Whether working in a team that has multiple members needing access to the database or creating and deleting test users to simulate database privileges, knowing how to add and remove database users is important.
 
 In this short guide, we will cover the basics of creating and deleting database users in [PostgreSQL](/intro/database-glossary#postgresql). These commands will have you ready to get started on granting database access and establish a foundation for future [role management](https://www.prisma.io/dataguide/postgresql/authentication-and-authorization/role-management).
-
 
 ## How do you create PostgreSQL users?
 
@@ -29,7 +28,7 @@ createuser <options>
 CREATE USER <name> <options>
 ```
 
-The [options component](https://www.postgresql.org/docs/current/app-createuser.html) of either method is where you can define parameters such as whether this user can create databases, is a superuser, and the need for a password when connecting to the server. 
+The [options component](https://www.postgresql.org/docs/current/app-createuser.html) of either method is where you can define parameters such as whether this user can create databases, is a superuser, and the need for a password when connecting to the server.
 
 The command line syntax can look something like for creating `user1`:
 
@@ -38,6 +37,8 @@ createuser --createdb --password user1
 ```
 
 In addition to creating users, it is important to know the different privileges that can be granted so users are only able to work with the database in specified ways. For the purpose of this guide we are just covering the basics to get started, but you can read more about [granting privileges in PostgreSQL](https://www.prisma.io/dataguide/postgresql/authentication-and-authorization/managing-privileges) for more advanced settings.
+
+<PostgresCallout />
 
 ## How do you delete PostgreSQL users?
 
@@ -65,6 +66,6 @@ dropuser --if-exists user1
 
 ## Conclusion
 
-In this quick guide, we covered the basics of creating and deleting users for PostgreSQL databases as well as some additional options. 
+In this quick guide, we covered the basics of creating and deleting users for PostgreSQL databases as well as some additional options.
 
 Once your users are created, we have additional informative articles diving deeper in [user role management](https://www.prisma.io/dataguide/postgresql/authentication-and-authorization/role-management) in PostgreSQL as well as [user authentication](https://www.prisma.io/dataguide/postgresql/authentication-and-authorization/configuring-user-authentication).

--- a/content/04-postgresql/14-short-guides/03-connection-uris.mdx
+++ b/content/04-postgresql/14-short-guides/03-connection-uris.mdx
@@ -51,6 +51,8 @@ pe%40ce%26lo%5C%2F3
 
 Keep this in mind as you build your connection URIs.
 
+<PostgresCallout />
+
 ## A quick overview
 
 Before we get into the details, we can look at the spec for a PostgreSQL connection URI:

--- a/content/04-postgresql/14-short-guides/04-exporting-schemas.mdx
+++ b/content/04-postgresql/14-short-guides/04-exporting-schemas.mdx
@@ -45,6 +45,8 @@ Using this information, you could export the schema of a database called `SALES`
 pg_dump --username=sales_reporter --password --schema-only SALES > sales_database_schema.sql
 ```
 
+<PostgresCallout />
+
 ## Modifying the export behavior
 
 The basic usage discussed above will output every structure related to the database in question. We can modify this behavior with a number of additional options and in some cases, with the related `pg_dumpall` command.

--- a/content/09-database-tools/01-top-11-nodejs-orms-query-builders-and-database-libraries.mdx
+++ b/content/09-database-tools/01-top-11-nodejs-orms-query-builders-and-database-libraries.mdx
@@ -32,6 +32,8 @@ The month of data considered for this article is **January 15 2022 to February 1
 
 This criteria is not exhaustive and you should choose the tool that best suits your project and programming preferences.
 
+<PostgresCallout />
+
 ## SQL, query builders, and ORMs
 
 Libraries to query and manipulate data can broadly be grouped into three categories, each operating at a different level of abstraction.

--- a/content/09-database-tools/02-evaluating-type-safety-in-the-top-8-typescript-orms.md
+++ b/content/09-database-tools/02-evaluating-type-safety-in-the-top-8-typescript-orms.md
@@ -91,6 +91,8 @@ This means that attempting to access `post` fields that weren't selected, like `
 
 Prisma's unique design of generating a local CRUD client that encodes your data model allows it to achieve an unparalleled level of type safety among TypeScript ORMs. When using Prisma to manipulate and query data from your database, you'll have accurate typings for nested relation queries and also partial queries that modify the shape of returned models.
 
+<PostgresCallout />
+
 ## Sequelize
 
 ### Evaluation summary

--- a/content/09-database-tools/03-connection-pooling.mdx
+++ b/content/09-database-tools/03-connection-pooling.mdx
@@ -62,6 +62,8 @@ As discussed earlier, when forming a connection, a fairly long series of operati
 
 In this system, clients connect to the connection pooler instead of directly to the database. The client treats the pooler as if it were the database itself and the pooler interprets queries to hand an appropriate connection to the client. One thing to notice is that there is still overhead involved in opening and closing connections between the clients and the pooler. These connections, however, typically have lower overhead because the majority of the heavy processes occur when establishing connections to the database itself.
 
+<PostgresCallout />
+
 ## How does connection pooling work?
 
 A connection pooler is responsible for opening, closing and maintaining connections to the database on behalf of clients. It does so by following algorithms similar to that which a caching system might use.

--- a/content/10-managing-databases/01-database-troubleshooting.mdx
+++ b/content/10-managing-databases/01-database-troubleshooting.mdx
@@ -107,6 +107,8 @@ This section contains several different kinds of logging information, including 
 
 ![DigitalOcean Recent Logs section](../dataguide-images/database-troubleshooting/do-recent-logs.png)
 
+<PostgresCallout />
+
 ## Networking issues
 
 Network-related issues can cause your database to be unavailable or seem to be down. In a three-tier application consisting of the client tier, the application tier (the back end), and the data tier (the database), networking issues can arise between the three tiers.

--- a/content/10-managing-databases/02-how-to-spot-bottlenecks-in-performance.mdx
+++ b/content/10-managing-databases/02-how-to-spot-bottlenecks-in-performance.mdx
@@ -53,6 +53,8 @@ For example, DigitalOcean's query statistics surfaces this information in tabula
 
 ![DigitalOcean Query Statistics section](../dataguide-images/database-bottlenecks/do-query-statistics.png)
 
+<PostgresCallout />
+
 ## Unindexed tables
 
 [Indexes](/intro/database-glossary#index) for a database table are conceptually similar to indexes in a book. Without an index in a book, you're left to look through every page to find the topic you're interested in. If, instead, the book has an index, you can search for a particular topic in the index first and you will be pointed to the correct page or pages. This drastically decreases the time it takes to find the information you're looking for.

--- a/content/10-managing-databases/03-syncing-development-databases-between-team-members.mdx
+++ b/content/10-managing-databases/03-syncing-development-databases-between-team-members.mdx
@@ -46,6 +46,8 @@ Having developers connect to a shared remote development database can alleviate 
 
 The downside to using a shared remote development database is that it requires additional resources to be running, possibly incurring additional cost. Additionally, if all developers are working against the same database, it can be easy to overwrite data. Another potential issue is if schema changes are adopted by team members asynchronously, out-of-band changes might negatively affect the state of the data, making it difficult to work with.
 
+<PostgresCallout />
+
 ## Ongoing database updates
 
 Whether locally or remotely, once developers are set up with a database to work against, they will need to continuously check for updates to the database schema and possibly the data in the database itself. This can be difficult if team sizes are large and changes are made frequently.

--- a/content/10-managing-databases/08-testing-in-production.mdx
+++ b/content/10-managing-databases/08-testing-in-production.mdx
@@ -34,6 +34,8 @@ The focus for those who adopt a testing-in-production philosophy can be summariz
 - **Test with real data:** Database mocks or stubs and databases filled with dummy records cannot accurately replicate the data that your code will have to accommodate
 - **Minimize the area of impact for changes:** Changes can be tested more safely and effectively if you can limit and adjust the scope during testing and release
 
+<PostgresCallout />
+
 ## What risks are associated with testing in production?
 
 Many people are skeptical that the benefits of testing in production can outweigh the costs. Before we continue on, let's talk about some of the risks of this strategy and how it's possible to mitigate them.

--- a/content/10-managing-databases/09-backup-considerations.mdx
+++ b/content/10-managing-databases/09-backup-considerations.mdx
@@ -29,6 +29,8 @@ Before continuing, it may be helpful to underline what value proper backups can 
 - Auditing and compliance: Many industries have certain standards of backups and auditing trails for compliance reasons. You may be compelled to implement a robust backup routine as part of your agreement to handle user data in various capacities.
 - Reassurance when making changes: Having reliable backups make changing your software, environment, or operations less dangerous. You can make changes with confidence knowing that you are not risking your organization's data if something goes wrong.
 
+<PostgresCallout />
+
 ## Types of backups
 
 There are many different _types_ of backups that you may want to consider. In this section, we'll cover some of the different backups you can perform and how they may fit together into a more comprehensive system.

--- a/content/10-managing-databases/10-intro-to-full-text-search.mdx
+++ b/content/10-managing-databases/10-intro-to-full-text-search.mdx
@@ -25,6 +25,8 @@ In contrast to regular database queries, full-text search is language-aware. Thi
 
 Full-text search often also includes the ability to rank and sort results based on their relative similarity to the user's query. This can help the engine display the most appropriate results first or disqualify low-ranking items unless explicitly requested.
 
+<PostgresCallout />
+
 ## The importance of indexing
 
 While many database operations can be improved by indexing, full-text search is especially dependent on an asynchronous indexing processes.

--- a/content/11-serverless/01-what-is-serverless.mdx
+++ b/content/11-serverless/01-what-is-serverless.mdx
@@ -46,6 +46,8 @@ In general, serverless databases are implemented using a tiered architecture. Th
 
 With this model, both the computational and storage resources can be scaled independently in the background according to demand. The user does not control the scaling. Instead, they are charged for the queries they execute and the amount of data they are storing.
 
+<PostgresCallout />
+
 ## Weighing trade-offs
 
 Now that we've talked about serverless is and how it generally works from a user's perspective, we can start to identify where serverless solutions are a good fit.

--- a/content/11-serverless/02-serverless-comparison.mdx
+++ b/content/11-serverless/02-serverless-comparison.mdx
@@ -612,6 +612,8 @@ Deno Deploy hopes to provide you with a unified developing experience by using t
 
 Prisma Accelerate provides a solution for this problem by acting as an intermediary to a database. Serverless instances can instead connect to Prisma Accelerate which manages the connection pooling automatically to avoid failed or delayed serverless evocations due to resource contention.
 
+<PostgresCallout />
+
 ## Wrapping up
 
 To summarize the serverless offerings we've covered, we've distilled some of the details into the following table to make it easier to compare at a glance. We'll only include the serverless compute options to avoid confusion:

--- a/content/11-serverless/03-serverless-challenges.mdx
+++ b/content/11-serverless/03-serverless-challenges.mdx
@@ -36,6 +36,8 @@ These solutions start to blur the line a bit as to what constitutes a serverless
 
 A recent alternative to preallocating resources has been to sidestep the problem by switching to a lighter runtime environment. Runtimes like V8 have a much different execution strategy than traditional serverless and are able to avoid cold start problems by using different isolation technologies and a more pared down environment. They avoid cold start issues at the expense of compatibility with functions that have dependencies on a more robust environment.
 
+<PostgresCallout />
+
 ## Application design constraints
 
 Another challenge that is fundamental to the serverless model is the application design it imposes. Serverless platforms are only useful for applications that can work within their constraints. Some of these are inherent in cloud computing in general, while other requirements are dictated by the serverless model specifically.

--- a/content/11-serverless/04-traditional-vs-serverless-databases.mdx
+++ b/content/11-serverless/04-traditional-vs-serverless-databases.mdx
@@ -42,7 +42,7 @@ This comes at the cost of a greater management burden. All levels of the system 
 
 ### Managed databases
 
-_Managed databases_ are a product offered by most cloud providers as an alternative to managing your own infrastructure. Instead, the provider manages the server configuration and database software and exposes options to the user to allow them to configure and tweak the behavior.
+_Managed databases_ are a product offered by most cloud providers as an alternative to managing your own infrastructure — one of [the main ways to host PostgreSQL](/postgresql/5-ways-to-host-postgresql). Instead, the provider manages the server configuration and database software and exposes options to the user to allow them to configure and tweak the behavior.
 
 With managed databases, the provider takes responsibility for:
 
@@ -68,6 +68,8 @@ _Serverless databases_ are a relatively new approach offered by cloud providers 
 In practice, this allows serverless databases to be treated as an infinitely large repository where data can be stored, operated on, and retrieved. The backend storage will be scaled out as needed and the number of query executors will also be adjusted according to demand. The user only needs to access the database through an API-like interface that routes commands to the correct components automatically.
 
 Serverless databases require the least amount of operational management of any of the options we've discussed. This allows you to use your database as if it were an external service rather than as a component of your infrastructure that you must keep operational.
+
+<PostgresCallout />
 
 ## When to use traditional databases and serverless databases
 

--- a/content/11-serverless/05-serverless-glossary.mdx
+++ b/content/11-serverless/05-serverless-glossary.mdx
@@ -22,6 +22,8 @@ Checkout the [Prisma Data Platform](https://pris.ly/dg/pdp) to manage all of you
 
 </PrismaOutlinks>
 
+<PostgresCallout />
+
 ## Terminology
 
 <dl>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -28,7 +28,9 @@ Learn the basics of what databases are, why they are so important for most softw
 <DocLink
   icon="file"
   text="Glossary of common database terminology"
-  href={'/intro/database-glossary'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/database-glossary'
+  }
 />
 
 ## [Data modeling](/datamodeling)
@@ -153,7 +155,9 @@ PostgreSQL is a feature rich object-relational database that offers incredible p
 <DocLink
   icon="file"
   text="Setting up a local PostgreSQL database"
-  href={'/postgresql/setting-up-a-local-postgresql-database'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/setting-up-a-local-postgresql-database'
+  }
 />
 <DocLink
   icon="file"
@@ -163,7 +167,9 @@ PostgreSQL is a feature rich object-relational database that offers incredible p
 <DocLink
   icon="file"
   text="Connecting to PostgreSQL databases"
-  href={'/postgresql/connecting-to-postgresql-databases'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connecting-to-postgresql-databases'
+  }
 />
 <DocLink
   icon="file"
@@ -200,7 +206,9 @@ PostgreSQL is a feature rich object-relational database that offers incredible p
 <DocLink
   icon="file"
   text="An introduction to PostgreSQL data types"
-  href={'/postgresql/introduction-to-data-types'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/introduction-to-data-types'
+  }
 />
 <DocLink
   icon="file"
@@ -280,7 +288,9 @@ PostgreSQL is a feature rich object-relational database that offers incredible p
 <DocLink
   icon="file"
   text="&emsp;&emsp;&bull;&nbsp; Introduction to PostgreSQL connection URIs"
-  href={'/postgresql/short-guides/connection-uris'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris'
+  }
 />
 <DocLink
   icon="file"
@@ -290,7 +300,9 @@ PostgreSQL is a feature rich object-relational database that offers incredible p
 <DocLink
   icon="file"
   text="Working with dates in PostgreSQL"
-  href={'/postgresql/date-types'}
+  href={
+    'https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/date-types'
+  }
 />
 
 ## [MySQL](/mysql)

--- a/src/components/cta/EndCta.tsx
+++ b/src/components/cta/EndCta.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import styled from 'styled-components'
+import { resolveCta, buildCtaUrl, CONSOLE_URL } from '../../cta'
+
+// End-of-article Prisma Postgres CTA.
+// Auto-rendered from the page slug. Strong (panel + buttons) on high-intent
+// pages, soft (single inline link to the product page) elsewhere. Suppressed
+// on index pages.
+
+const Panel = styled.div`
+  background: #e1f5ee;
+  border-radius: 8px;
+  padding: 24px;
+  margin: 2.5rem 0 1rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+`
+
+const PanelText = styled.div`
+  flex: 1;
+  min-width: 240px;
+`
+
+const Title = styled.p`
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #0f6e56;
+`
+
+const Body = styled.p`
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #187367;
+`
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+`
+
+const PrimaryButton = styled.a`
+  background: #16a394;
+  color: #ffffff;
+  border-radius: 4px;
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover,
+  &:link,
+  &:visited,
+  &:active {
+    color: #ffffff;
+  }
+  &:hover {
+    background: #187367;
+  }
+`
+
+const SecondaryLink = styled.a`
+  color: #16a394;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+  white-space: nowrap;
+  &:hover {
+    color: #187367;
+  }
+`
+
+const SoftCta = styled.p`
+  margin: 2.5rem 0 1rem;
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+  font-size: 14px;
+  color: #4a5568;
+
+  a {
+    color: #16a394;
+    font-weight: 600;
+    text-decoration: none;
+    &:hover {
+      color: #187367;
+    }
+  }
+`
+
+interface EndCtaProps {
+  slug?: string
+}
+
+const EndCta = ({ slug = '' }: EndCtaProps) => {
+  const cta = resolveCta(slug)
+
+  // No commercial push on section index pages.
+  if (cta.isIndex) return null
+
+  if (cta.strength === 'soft') {
+    const href = buildCtaUrl(cta, 'end_cta', { forceProduct: true })
+    return (
+      <SoftCta
+        data-cta-cluster={cta.cluster}
+        data-cta-placement="end_cta"
+        data-cta-slug={cta.articleSlug}
+      >
+        {cta.copy.end.body}{' '}
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          Explore Prisma Postgres →
+        </a>
+      </SoftCta>
+    )
+  }
+
+  const primaryHref = buildCtaUrl(cta, 'end_cta')
+  const isConsole = primaryHref.startsWith(CONSOLE_URL)
+  const primaryText = isConsole ? 'Create a database' : 'Explore Prisma Postgres'
+  const secondaryHref = isConsole
+    ? buildCtaUrl(cta, 'end_cta', { forceProduct: true })
+    : cta.docsUrl
+  const secondaryText = isConsole ? 'Explore Prisma Postgres' : 'Read the docs'
+
+  return (
+    <Panel
+      data-cta-cluster={cta.cluster}
+      data-cta-placement="end_cta"
+      data-cta-slug={cta.articleSlug}
+    >
+      <PanelText>
+        <Title>{cta.copy.end.title}</Title>
+        <Body>{cta.copy.end.body}</Body>
+      </PanelText>
+      <Actions>
+        <PrimaryButton href={primaryHref} target="_blank" rel="noopener noreferrer">
+          {primaryText}
+        </PrimaryButton>
+        <SecondaryLink href={secondaryHref} target="_blank" rel="noopener noreferrer">
+          {secondaryText}
+        </SecondaryLink>
+      </Actions>
+    </Panel>
+  )
+}
+
+export default EndCta

--- a/src/components/cta/EndCta.tsx
+++ b/src/components/cta/EndCta.tsx
@@ -11,7 +11,7 @@ const Panel = styled.div`
   background: #e1f5ee;
   border-radius: 8px;
   padding: 24px;
-  margin: 2.5rem 0 1rem;
+  margin: 1rem 0;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -78,7 +78,7 @@ const SecondaryLink = styled.a`
 `
 
 const SoftCta = styled.p`
-  margin: 2.5rem 0 1rem;
+  margin: 1rem 0;
   padding-top: 16px;
   border-top: 1px solid #e2e8f0;
   font-size: 14px;

--- a/src/components/cta/MobileStickyCta.tsx
+++ b/src/components/cta/MobileStickyCta.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { resolveCta, buildCtaUrl, CONSOLE_URL } from '../../cta'
+
+// Dismissible sticky bottom CTA, mobile + high-intent pages only.
+// Appears after the reader scrolls ~40% of the viewport; dismissal is
+// remembered for the session.
+
+const DISMISS_KEY = 'pp-mobile-sticky-dismissed'
+
+const Bar = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 130;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #ffffff;
+  border-top: 1px solid #cbd5e0;
+  box-shadow: 0px -2px 8px rgba(47, 55, 71, 0.08);
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+`
+
+const Text = styled.span`
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a202c;
+`
+
+const CreateButton = styled.a`
+  background: #16a394;
+  color: #ffffff;
+  border-radius: 4px;
+  padding: 8px 14px;
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover,
+  &:link,
+  &:visited,
+  &:active {
+    color: #ffffff;
+  }
+`
+
+const Dismiss = styled.button`
+  background: none;
+  border: none;
+  color: #718096;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+`
+
+interface MobileStickyCtaProps {
+  slug?: string
+}
+
+const MobileStickyCta = ({ slug = '' }: MobileStickyCtaProps) => {
+  const cta = resolveCta(slug)
+  const [visible, setVisible] = useState(false)
+  const [dismissed, setDismissed] = useState(true)
+
+  useEffect(() => {
+    if (!cta.showMobileSticky) return
+    if (typeof window === 'undefined') return
+    if (window.sessionStorage.getItem(DISMISS_KEY) === '1') return
+
+    setDismissed(false)
+    const onScroll = () => {
+      if (window.scrollY > window.innerHeight * 0.4) setVisible(true)
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [cta.showMobileSticky])
+
+  if (!cta.showMobileSticky || dismissed || !visible) return null
+
+  const href = buildCtaUrl(cta, 'mobile_sticky')
+  const isConsole = href.startsWith(CONSOLE_URL)
+
+  const onDismiss = () => {
+    setDismissed(true)
+    if (typeof window !== 'undefined') window.sessionStorage.setItem(DISMISS_KEY, '1')
+  }
+
+  return (
+    <Bar
+      data-cta-cluster={cta.cluster}
+      data-cta-placement="mobile_sticky"
+      data-cta-slug={cta.articleSlug}
+    >
+      <Text>{isConsole ? 'Create a Prisma Postgres database' : 'Explore Prisma Postgres'}</Text>
+      <CreateButton href={href} target="_blank" rel="noopener noreferrer">
+        {isConsole ? 'Create' : 'Explore'}
+      </CreateButton>
+      <Dismiss type="button" aria-label="Dismiss" onClick={onDismiss}>
+        ×
+      </Dismiss>
+    </Bar>
+  )
+}
+
+export default MobileStickyCta

--- a/src/components/cta/PostgresCallout.tsx
+++ b/src/components/cta/PostgresCallout.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useLocation } from '@reach/router'
+import PrismaLogo from '../../icons/PrismaLogo'
+import { resolveCta, buildCtaUrl, CONSOLE_URL, ClusterId } from '../../cta'
+
+// Inline, contextual Prisma Postgres callout for placing inside article bodies
+// (MDX). Resolves copy/destination from the current page by default; pass an
+// explicit `cluster` to override (e.g. on a page whose section default doesn't
+// match the surrounding content).
+
+const Callout = styled.div`
+  background: #e1f5ee;
+  border: 1px solid #9fe1cb;
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin: 24px 0;
+`
+
+const Label = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+
+  .icon {
+    background: #ffffff;
+    border-radius: 4px;
+    width: 24px;
+    height: 24px;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  span {
+    font-size: 13px;
+    font-weight: 600;
+    color: #0f6e56;
+  }
+`
+
+const Title = styled.p`
+  margin: 0 0 6px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #0f6e56;
+`
+
+const Body = styled.p`
+  margin: 0 0 14px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #187367;
+`
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+`
+
+const PrimaryButton = styled.a`
+  background: #16a394;
+  color: #ffffff;
+  border-radius: 4px;
+  padding: 7px 14px;
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+
+  &:hover,
+  &:link,
+  &:visited,
+  &:active {
+    color: #ffffff;
+  }
+  &:hover {
+    background: #187367;
+  }
+`
+
+const SecondaryLink = styled.a`
+  color: #16a394;
+  font-weight: 600;
+  font-size: 13px;
+  text-decoration: none;
+  &:hover {
+    color: #187367;
+  }
+`
+
+interface PostgresCalloutProps {
+  cluster?: ClusterId
+}
+
+const PostgresCallout = ({ cluster }: PostgresCalloutProps) => {
+  const location = useLocation()
+  // Resolve from the current page; an explicit `cluster` overrides the mapping.
+  const resolved = resolveCta(location?.pathname || '', cluster)
+
+  const primaryHref = buildCtaUrl(resolved, 'inline_cta')
+  const isConsole = primaryHref.startsWith(CONSOLE_URL)
+  const primaryText = isConsole ? 'Create a database' : 'Explore Prisma Postgres'
+
+  return (
+    <Callout
+      data-cta-cluster={resolved.cluster}
+      data-cta-placement="inline_cta"
+      data-cta-slug={resolved.articleSlug}
+    >
+      <Label>
+        <span className="icon">
+          <PrismaLogo color="#16a394" />
+        </span>
+        <span>Prisma Postgres</span>
+      </Label>
+      <Title>{resolved.copy.inline.title}</Title>
+      <Body>{resolved.copy.inline.body}</Body>
+      <Actions>
+        <PrimaryButton href={primaryHref} target="_blank" rel="noopener noreferrer">
+          {primaryText}
+        </PrimaryButton>
+        <SecondaryLink href={resolved.docsUrl} target="_blank" rel="noopener noreferrer">
+          Read the docs →
+        </SecondaryLink>
+      </Actions>
+    </Callout>
+  )
+}
+
+export default PostgresCallout

--- a/src/components/customMdx/index.tsx
+++ b/src/components/customMdx/index.tsx
@@ -14,6 +14,7 @@ import AuthorInfo from './authorInfo'
 import Footnote from './footnote'
 import Sidenote from './sideNote'
 import PrismaOutlinks from './prismaOutlinks'
+import PostgresCallout from '../cta/PostgresCallout'
 import AnchorItem from './anchor-item'
 import { withPrefix } from 'gatsby'
 
@@ -34,6 +35,7 @@ export default {
   ButtonLink,
   Subsections,
   PrismaOutlinks,
+  PostgresCallout,
   DocLink,
   footnote: Footnote,
   Sidenote,

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,6 +7,7 @@ import Sidebar from '../components/sidebar'
 import { HeaderProps } from '../interfaces/Layout.interface'
 import { withPrefix } from 'gatsby'
 import { useLocation } from '@reach/router'
+import { headerCtaUrl } from '../cta'
 
 type HeaderViewProps = {
   headerProps: HeaderProps
@@ -199,8 +200,14 @@ const Header = ({ headerProps }: HeaderViewProps) => {
         )}
         <PrismaLink>
           <SearchComponent hitsStatus={changeHitsStatus} location={location} header />
-          <PrismaButton href="https://www.prisma.io" target="_blank">
-            Explore Prisma
+          <PrismaButton
+            href={headerCtaUrl()}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-cta-cluster="postgres_global"
+            data-cta-placement="header_cta"
+          >
+            Prisma Postgres
           </PrismaButton>
         </PrismaLink>
       </div>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -92,7 +92,7 @@ const Layout: React.FunctionComponent<LayoutProps> = ({ children, isHomePage, sl
       <Wrapper>
         {!isHomePage && (
           <NotMobile>
-            <Sidebar isMobile={false} />
+            <Sidebar isMobile={false} slug={slug} />
           </NotMobile>
         )}
         <Content moveUp={isHomePage}>

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -9,6 +9,17 @@ type SEOProps = {
   image?: string
 }
 
+// Build a well-formed absolute OG/Twitter image URL.
+// Frontmatter `metaImage` is sometimes a content-relative path
+// (e.g. ../dataguide-images/...); left raw it concatenates into malformed
+// "dataguide.." URLs. Mirror the in-article <img> handling by stripping the
+// relative `../` prefixes, then join cleanly to siteUrl + pathPrefix.
+const buildMetaImageURL = (siteUrl: string, pathPrefix: string, img: string): string => {
+  if (/^https?:\/\//.test(img)) return img
+  const cleaned = img.replace(/\.\.\//g, '').replace(/^\/+/, '')
+  return `${siteUrl}${pathPrefix}/${cleaned}`.replace(/([^:])\/{2,}/g, '$1/')
+}
+
 const SEO = ({ title, description, image }: SEOProps) => {
   const location = useLocation()
   const { site } = useStaticQuery(query)
@@ -26,7 +37,7 @@ const SEO = ({ title, description, image }: SEOProps) => {
     },
   } = site
 
-  const metaImageURL = image ? `${siteUrl + pathPrefix}${image}` : `${siteUrl + pathPrefix}${oUrl}`
+  const metaImageURL = buildMetaImageURL(siteUrl, pathPrefix, image || oUrl)
 
   let canonicalUrl = `${siteUrl}${location.pathname === '/' ? '' : location.pathname}`.replace(
     /\/$/,

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -12,12 +12,16 @@ type SEOProps = {
 // Build a well-formed absolute OG/Twitter image URL.
 // Frontmatter `metaImage` is sometimes a content-relative path
 // (e.g. ../dataguide-images/...); left raw it concatenates into malformed
-// "dataguide.." URLs. Mirror the in-article <img> handling by stripping the
-// relative `../` prefixes, then join cleanly to siteUrl + pathPrefix.
+// "dataguide.." URLs. Normalize by dropping relative path segments ('.', '..')
+// entirely — splitting on '/' avoids the reconstruction pitfall of a single
+// regex replace — then join cleanly to siteUrl + pathPrefix.
 const buildMetaImageURL = (siteUrl: string, pathPrefix: string, img: string): string => {
   if (/^https?:\/\//.test(img)) return img
-  const cleaned = img.replace(/\.\.\//g, '').replace(/^\/+/, '')
-  return `${siteUrl}${pathPrefix}/${cleaned}`.replace(/([^:])\/{2,}/g, '$1/')
+  const cleaned = img
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== '.' && segment !== '..')
+    .join('/')
+  return `${siteUrl}${pathPrefix}/${cleaned}`
 }
 
 const SEO = ({ title, description, image }: SEOProps) => {

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -65,7 +65,7 @@ const getLeftPane = (allEdges: any) =>
 const getRightPane = (allEdges: any) =>
   allEdges.filter((edge: any) => edge.node.fields.slug.match(paneRegex))
 
-const SidebarLayout = ({ isMobile }: any) => {
+const SidebarLayout = ({ isMobile, slug }: any) => {
   const { allMdx }: AllArticles = useAllArticlesQuery()
   return !isMobile ? (
     <StickyContainer>
@@ -73,7 +73,7 @@ const SidebarLayout = ({ isMobile }: any) => {
         <Sticky topOffset={0}>
           {({ style, isSticky }: any) => (
             <Sidebar style={style} isSticky={isSticky} id="sidebar-container">
-              <Promo />
+              <Promo slug={slug} />
               <List>
                 <Tree edges={allMdx.edges} />
               </List>

--- a/src/components/sidebar/promo.tsx
+++ b/src/components/sidebar/promo.tsx
@@ -1,151 +1,71 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
+import { resolveCta, buildCtaUrl, CONSOLE_URL } from '../../cta'
 
-const PromoLink = styled.a`
+// Cluster-aware Prisma Postgres sidebar promo.
+// Copy and destination are resolved from the current page's slug via the
+// shared CTA config (src/cta). Replaces the legacy randomized Pulse-era promos.
+
+const PromoCard = styled.div`
   margin: 1.5rem 15px 15px 15px;
-  border-width: 1px;
-  border-style: solid;
+  border: 1px solid #16a394;
   border-radius: 5px;
-  padding: 5px 10px;
+  padding: 14px;
   font-size: 0.8rem;
-  text-decoration: none;
-  display: block;
+`
 
-  /* Default color */
-  &,
+const PromoText = styled.p`
+  margin: 0 0 12px;
+  color: #187367;
+  font-size: 14px;
+  line-height: 1.5;
+`
+
+const PromoButton = styled.a`
+  display: block;
+  text-align: center;
+  background: #16a394;
+  color: #ffffff;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover,
   &:link,
   &:visited,
   &:active {
-    border-color: #16a394;
-    color: #16a394;
+    color: #ffffff;
   }
 
   &:hover {
-    border-color: #187367;
-    color: #187367;
-  }
-
-  /* teal color */
-  &.sidebar-promo-teal,
-  &.sidebar-promo-teal:link,
-  &.sidebar-promo-teal:visited,
-  &.sidebar-promo-teal:active {
-    border-color: #16a394;
-    color: #16a394;
-  }
-
-  &.sidebar-promo-teal:hover {
-    border-color: #187367;
-    color: #187367;
-  }
-
-  /* indigo color */
-  &.sidebar-promo-indigo,
-  &.sidebar-promo-indigo:link,
-  &.sidebar-promo-indigo:visited,
-  &.sidebar-promo-indigo:active {
-    border-color: #5a67d8;
-    color: #5a67d8;
-  }
-
-  &.sidebar-promo-indigo:hover {
-    border-color: #4c51bf;
-    color: #4c51bf;
+    background: #187367;
   }
 `
-type PromoOption = {
-  text: string
-  link: string
-  color: 'teal' | 'indigo'
+
+interface PromoProps {
+  slug?: string
 }
 
-const promoOptions: PromoOption[] = [
-  {
-    text: `Want real-time updates from your database without manual polling?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/real-time-updates-without-polling',
-    color: 'teal',
-  },
-  {
-    text: `Need to sync data instantly to your applications?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/sync-data-to-apps',
-    color: 'indigo',
-  },
-  {
-    text: `Want to react to database changes in your app, as they happen?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/react-to-database-changes',
-    color: 'teal',
-  },
-  {
-    text: `Working on real-time interactions in your distributed systems?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/real-time-interactions-distributed-systems',
-    color: 'indigo',
-  },
-  {
-    text: `Working on critical workflows triggered by changes in your db?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/critical-workflows-triggered-by-db',
-    color: 'indigo',
-  },
-  {
-    text: `Need your database queries to be 1000x faster?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/queries-1000x-faster',
-    color: 'teal',
-  },
-  {
-    text: `Working on highly scaleable serverless or edge applications?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/scaleable-serverless-edge-apps',
-    color: 'indigo',
-  },
-  {
-    text: `Want to to enhance response times while reducing database load?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/enhance-response-times-reduce-load',
-    color: 'teal',
-  },
-  {
-    text: `Interested in query caching in just a few lines of code?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/caching-few-lines-of-code',
-    color: 'teal',
-  },
-  {
-    text: `Does your serverless architecture handle global scaling effectively?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/serverless-architecture-global-scaling',
-    color: 'indigo',
-  },
-  {
-    text: `Easily identify and fix slow SQL queries in your app.`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/identify-fix-sql-queries',
-    color: 'teal',
-  },
-  {
-    text: `Looking to uncover inefficient database operations?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/inefficient-db-operations',
-    color: 'indigo',
-  },
-  {
-    text: `Curious about the SQL queries Prisma ORM generates?`,
-    link: 'https://pris.ly/dataguide-sidebar-promo/sql-queries-in-orm',
-    color: 'teal',
-  },
-]
-
-export const Promo = () => {
-  const [promo, setPromo] = useState(promoOptions[0])
-  const hasMounted = useRef(false)
-
-  useEffect(() => {
-    if (!hasMounted.current) {
-      const newState = promoOptions[Math.floor(Math.random() * promoOptions.length)]
-      setPromo(newState)
-      hasMounted.current = true
-    }
-  }, [])
+export const Promo = ({ slug = '' }: PromoProps) => {
+  const cta = resolveCta(slug)
+  const href = buildCtaUrl(cta, 'sidebar_cta')
+  const isConsole = href.startsWith(CONSOLE_URL)
+  const buttonText = isConsole ? 'Create a database' : 'Explore Prisma Postgres'
 
   return (
-    <PromoLink
-      className={`sidebar-promo sidebar-promo-${promo.color}`}
-      href={promo.link}
-      target="_blank"
-    >
-      {promo.text}
-    </PromoLink>
+    <PromoCard className="sidebar-promo">
+      <PromoText>{cta.copy.sidebar}</PromoText>
+      <PromoButton
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-cta-cluster={cta.cluster}
+        data-cta-placement="sidebar_cta"
+        data-cta-slug={cta.articleSlug}
+      >
+        {buttonText}
+      </PromoButton>
+    </PromoCard>
   )
 }

--- a/src/cta/clusters.ts
+++ b/src/cta/clusters.ts
@@ -1,0 +1,128 @@
+// Prisma Postgres conversion clusters.
+//
+// Single source of truth for CTA copy, destination, and UTM campaign across
+// every Data Guide placement (sidebar, inline, end-of-article, mobile sticky).
+// Tune copy/destinations here; components stay presentational.
+
+export type Destination = 'product' | 'console'
+
+export type ClusterId =
+  | 'postgres_hosting'
+  | 'serverless_pooling'
+  | 'performance'
+  | 'managed_ops'
+  | 'orm_stack'
+  | 'database_choice'
+
+export interface ClusterCopy {
+  sidebar: string
+  inline: { title: string; body: string }
+  end: { title: string; body: string }
+}
+
+export interface ClusterDef {
+  // utm_campaign value. Folded to the report's canonical campaign set:
+  // postgres_hosting | serverless_pooling | managed_ops | orm_stack | database_choice
+  campaign: string
+  // Where the *primary* action points for high-intent (strong) placements.
+  destination: Destination
+  copy: ClusterCopy
+}
+
+// Destination base URLs.
+export const PRODUCT_URL = 'https://www.prisma.io/postgres'
+export const CONSOLE_URL = 'https://console.prisma.io/login'
+export const DOCS_URL = 'https://www.prisma.io/docs/postgres'
+
+export const clusters: Record<ClusterId, ClusterDef> = {
+  postgres_hosting: {
+    campaign: 'postgres_hosting',
+    destination: 'console',
+    copy: {
+      sidebar: `Need to run this in production? Create a hosted Postgres database in seconds.`,
+      inline: {
+        title: `Skip the setup with Prisma Postgres`,
+        body: `If you want Postgres without provisioning instances, networking, backups, and pooling, Prisma Postgres gives you a hosted database in seconds.`,
+      },
+      end: {
+        title: `Create a hosted Postgres database`,
+        body: `Provision a production-ready Postgres database in seconds — no instances, networking, or backups to manage.`,
+      },
+    },
+  },
+  serverless_pooling: {
+    campaign: 'serverless_pooling',
+    destination: 'console',
+    copy: {
+      sidebar: `Building for serverless or edge? Prisma Postgres has built-in connection pooling.`,
+      inline: {
+        title: `Built-in pooling with Prisma Postgres`,
+        body: `Prisma Postgres includes built-in connection pooling, so serverless and edge apps use a regular Postgres connection string — no separate pooler to run.`,
+      },
+      end: {
+        title: `Try Postgres with built-in pooling`,
+        body: `Provision a hosted Postgres database in seconds — connection pooling, automated backups, and Query Insights included.`,
+      },
+    },
+  },
+  performance: {
+    campaign: 'managed_ops',
+    destination: 'console',
+    copy: {
+      sidebar: `Chasing slow queries? Prisma Postgres surfaces them with Query Insights.`,
+      inline: {
+        title: `Find slow queries with Query Insights`,
+        body: `Prisma Postgres includes Query Insights, so you can spot and fix slow queries on a hosted database without wiring up your own monitoring.`,
+      },
+      end: {
+        title: `Find slow queries with Prisma Postgres`,
+        body: `Spot and fix slow queries with built-in Query Insights on a fully managed Postgres database.`,
+      },
+    },
+  },
+  managed_ops: {
+    campaign: 'managed_ops',
+    destination: 'console',
+    copy: {
+      sidebar: `Tired of managing Postgres operations? Create a managed Postgres database.`,
+      inline: {
+        title: `Let Prisma Postgres handle the operations`,
+        body: `Prisma Postgres provisions a fully managed Postgres database with automated backups and connection pooling — so you can focus on your app, not the infrastructure.`,
+      },
+      end: {
+        title: `Create a managed Postgres database`,
+        body: `Hosted Postgres with automated backups, connection pooling, and Query Insights — ready in seconds.`,
+      },
+    },
+  },
+  orm_stack: {
+    campaign: 'orm_stack',
+    destination: 'product',
+    copy: {
+      sidebar: `Choosing a data layer? Pair Prisma ORM with hosted Prisma Postgres.`,
+      inline: {
+        title: `Pair Prisma ORM with Prisma Postgres`,
+        body: `Pair Prisma ORM with Prisma Postgres for an end-to-end typed data layer — hosted, pooled, and ready in seconds.`,
+      },
+      end: {
+        title: `Build with Prisma ORM and hosted Postgres`,
+        body: `Get a type-safe data layer and a hosted Postgres database that work together out of the box.`,
+      },
+    },
+  },
+  database_choice: {
+    campaign: 'database_choice',
+    destination: 'product',
+    copy: {
+      sidebar: `Need a database for your next project?`,
+      inline: {
+        title: `Need a hosted database?`,
+        body: `When you're ready to deploy, Prisma Postgres gives you a hosted Postgres database in seconds — with pooling and backups built in.`,
+      },
+      end: {
+        title: `Explore Prisma Postgres`,
+        body: `A hosted Postgres database for your next project, with connection pooling and backups built in.`,
+      },
+    },
+  },
+}

--- a/src/cta/index.ts
+++ b/src/cta/index.ts
@@ -1,0 +1,125 @@
+// Public API for the Prisma Postgres CTA layer.
+//
+// resolveCta(rawSlug) is the one entry point components use. Given any slug or
+// pathname (with or without numeric prefixes / the /dataguide path prefix) it
+// returns the cluster, priority, copy, and ready-to-use destination URLs.
+
+import {
+  clusters,
+  ClusterId,
+  ClusterDef,
+  Destination,
+  PRODUCT_URL,
+  CONSOLE_URL,
+  DOCS_URL,
+} from './clusters'
+import { sectionDefaults, slugOverrides, PageCta, Priority } from './pageMap'
+
+export type Placement = 'sidebar_cta' | 'inline_cta' | 'end_cta' | 'mobile_sticky' | 'body_link'
+
+export interface ResolvedCta {
+  cluster: ClusterId
+  clusterDef: ClusterDef
+  priority: Priority
+  isIndex: boolean
+  section: string
+  articleSlug: string
+  cleanSlug: string
+  copy: ClusterDef['copy']
+  docsUrl: string
+  // Strong placements (high intent) keep the cluster destination; soft
+  // placements always fall back to the product page.
+  strength: 'strong' | 'soft'
+  showInline: boolean
+  showMobileSticky: boolean
+}
+
+// Normalize a slug or pathname to `section/article` form.
+export function cleanSlug(raw: string): string {
+  return (raw || '')
+    .replace(/^https?:\/\/[^/]+/, '') // strip origin if a full URL
+    .replace(/^\/dataguide/, '') // strip Gatsby path prefix (prod only)
+    .replace(/\d{2,}-/g, '') // strip NN- content ordering prefixes
+    .replace(/\/index$/, '')
+    .replace(/^\/+|\/+$/g, '') // trim leading/trailing slashes
+    .toLowerCase()
+}
+
+function isIndexSlug(raw: string, clean: string): boolean {
+  return /index/.test(raw) || clean === '' || !clean.includes('/')
+}
+
+export function lookupPageCta(clean: string): PageCta {
+  if (slugOverrides[clean]) return slugOverrides[clean]
+  const section = clean.split('/')[0]
+  return sectionDefaults[section] || { cluster: 'database_choice', priority: 'low' }
+}
+
+// `clusterOverride` lets a caller (e.g. an explicitly-placed inline callout)
+// pick the cluster while keeping the page's resolved slug, priority, and tracking.
+export function resolveCta(rawSlug: string, clusterOverride?: ClusterId): ResolvedCta {
+  const clean = cleanSlug(rawSlug)
+  const section = clean.split('/')[0] || 'home'
+  const articleSlug = clean.split('/').filter(Boolean).pop() || section
+  const isIndex = isIndexSlug(rawSlug, clean)
+  const looked = lookupPageCta(clean)
+  const cluster = clusterOverride || looked.cluster
+  const priority = looked.priority
+  const clusterDef = clusters[cluster]
+  const strength: 'strong' | 'soft' = priority === 'high' ? 'strong' : 'soft'
+
+  return {
+    cluster,
+    clusterDef,
+    priority,
+    isIndex,
+    section,
+    articleSlug,
+    cleanSlug: clean,
+    copy: clusterDef.copy,
+    docsUrl: DOCS_URL,
+    strength,
+    showInline: priority !== 'low',
+    showMobileSticky: priority === 'high' && !isIndex,
+  }
+}
+
+interface BuildUrlOpts {
+  // Force the product page regardless of cluster destination (soft CTAs).
+  forceProduct?: boolean
+}
+
+function destinationUrl(dest: Destination, opts?: BuildUrlOpts): string {
+  if (opts?.forceProduct) return PRODUCT_URL
+  return dest === 'console' ? CONSOLE_URL : PRODUCT_URL
+}
+
+// Build a tracked CTA URL following the report's UTM scheme.
+export function buildCtaUrl(
+  resolved: Pick<ResolvedCta, 'clusterDef' | 'articleSlug'>,
+  placement: Placement,
+  opts?: BuildUrlOpts
+): string {
+  const base = destinationUrl(resolved.clusterDef.destination, opts)
+  const params = new URLSearchParams({
+    utm_source: 'dataguide',
+    utm_medium: placement,
+    utm_campaign: resolved.clusterDef.campaign,
+    utm_content: `${resolved.articleSlug}:${placement}`,
+  })
+  return `${base}?${params.toString()}`
+}
+
+// Global header CTA — page-agnostic, always points at the product page.
+export function headerCtaUrl(): string {
+  const params = new URLSearchParams({
+    utm_source: 'dataguide',
+    utm_medium: 'header_cta',
+    utm_campaign: 'postgres_global',
+    utm_content: 'header',
+  })
+  return `${PRODUCT_URL}?${params.toString()}`
+}
+
+export { PRODUCT_URL, CONSOLE_URL, DOCS_URL }
+export type { ClusterId, ClusterDef, Destination, Priority }

--- a/src/cta/pageMap.ts
+++ b/src/cta/pageMap.ts
@@ -1,0 +1,90 @@
+// Maps a Data Guide page to a CTA cluster + intent priority.
+//
+// Resolution order: exact clean-slug override -> section default.
+// Seeded from dataguide_article_audit.csv. Priority drives CTA strength:
+//   high   -> strong end CTA, inline callout eligible, mobile sticky eligible
+//   medium -> soft end CTA, no mobile sticky
+//   low    -> soft end CTA routed to the product page, no mobile sticky
+
+import { ClusterId } from './clusters'
+
+export type Priority = 'high' | 'medium' | 'low'
+
+export interface PageCta {
+  cluster: ClusterId
+  priority: Priority
+}
+
+// Defaults applied by top-level section (numeric prefix already stripped).
+export const sectionDefaults: Record<string, PageCta> = {
+  intro: { cluster: 'database_choice', priority: 'low' },
+  datamodeling: { cluster: 'database_choice', priority: 'low' },
+  types: { cluster: 'database_choice', priority: 'low' },
+  postgresql: { cluster: 'managed_ops', priority: 'high' },
+  mysql: { cluster: 'database_choice', priority: 'low' },
+  sqlite: { cluster: 'database_choice', priority: 'low' },
+  mssql: { cluster: 'database_choice', priority: 'medium' },
+  mongodb: { cluster: 'database_choice', priority: 'low' },
+  'database-tools': { cluster: 'orm_stack', priority: 'high' },
+  'managing-databases': { cluster: 'managed_ops', priority: 'medium' },
+  serverless: { cluster: 'serverless_pooling', priority: 'high' },
+  'just-for-fun': { cluster: 'database_choice', priority: 'low' },
+}
+
+// Per-page overrides, keyed by clean slug (no numeric prefix, no path prefix).
+export const slugOverrides: Record<string, PageCta> = {
+  // PostgreSQL hosting / RDS -> console, hosting copy
+  'postgresql/5-ways-to-host-postgresql': { cluster: 'postgres_hosting', priority: 'high' },
+  'postgresql/setting-up-postgresql-on-rds': { cluster: 'postgres_hosting', priority: 'high' },
+
+  // Connection pooling lives under database-tools but is a pooling/serverless fit
+  'database-tools/connection-pooling': { cluster: 'serverless_pooling', priority: 'high' },
+
+  // Performance / slow-query education -> Query Insights
+  'postgresql/reading-and-querying-data/optimizing-postgresql': {
+    cluster: 'performance',
+    priority: 'high',
+  },
+  'managing-databases/how-to-spot-bottlenecks-in-performance': {
+    cluster: 'performance',
+    priority: 'high',
+  },
+
+  // Managed-operations pain -> managed Postgres value
+  'managing-databases/database-troubleshooting': { cluster: 'managed_ops', priority: 'high' },
+  'managing-databases/backup-considerations': { cluster: 'managed_ops', priority: 'high' },
+  'managing-databases/testing-in-production': { cluster: 'managed_ops', priority: 'high' },
+  'managing-databases/intro-to-full-text-search': { cluster: 'managed_ops', priority: 'high' },
+  'managing-databases/syncing-development-databases-between-team-members': {
+    cluster: 'managed_ops',
+    priority: 'high',
+  },
+
+  // ORM / TypeScript -> product, ORM stack copy
+  'database-tools/top-nodejs-orms-query-builders-and-database-libraries': {
+    cluster: 'orm_stack',
+    priority: 'high',
+  },
+  'database-tools/evaluating-type-safety-in-the-top-8-typescript-orms': {
+    cluster: 'orm_stack',
+    priority: 'high',
+  },
+  'types/relational/what-is-an-orm': { cluster: 'orm_stack', priority: 'high' },
+  'types/relational/comparing-sql-query-builders-and-orms': {
+    cluster: 'orm_stack',
+    priority: 'high',
+  },
+  'types/relational/what-are-database-migrations': { cluster: 'orm_stack', priority: 'high' },
+  'types/relational/migration-strategies': { cluster: 'orm_stack', priority: 'high' },
+  'types/relational/expand-and-contract-pattern': { cluster: 'orm_stack', priority: 'high' },
+  'types/relational/infrastructure-architecture': { cluster: 'orm_stack', priority: 'high' },
+  'types/relational-vs-document-databases': { cluster: 'orm_stack', priority: 'medium' },
+
+  // Lower-intent education that would otherwise inherit a high section default
+  'managing-databases/microservices-vs-monoliths': { cluster: 'database_choice', priority: 'low' },
+  'managing-databases/introduction-to-OLAP-OLTP': { cluster: 'database_choice', priority: 'low' },
+  'managing-databases/introduction-database-caching': {
+    cluster: 'database_choice',
+    priority: 'low',
+  },
+}

--- a/src/templates/docs.tsx
+++ b/src/templates/docs.tsx
@@ -12,6 +12,8 @@ import { CreatePageContext } from '../interfaces/Layout.interface'
 import SocialShareSection from '../components/socialShareSection'
 import NextPrevious from '../components/nextPrevious'
 import AuthorDetails from '../components/authorDetails'
+import EndCta from '../components/cta/EndCta'
+import MobileStickyCta from '../components/cta/MobileStickyCta'
 
 type ArticleLayoutProps = ArticleQueryData & RouterProps & CreatePageContext
 
@@ -47,6 +49,7 @@ const ArticleLayout = ({ data, ...props }: ArticleLayoutProps) => {
         </section>
       )}
       <MDXRenderer>{body}</MDXRenderer>
+      {!isHomePage && <EndCta slug={modSlug} />}
       {authors && (
         <section>
           <AuthorDetails authors={authors} />
@@ -54,6 +57,7 @@ const ArticleLayout = ({ data, ...props }: ArticleLayoutProps) => {
       )}
       {!slug.includes('index') && <NextPrevious slug={modSlug} />}
       <PageBottom editDocsPath={`${docsLocation}/${parent.relativePath}`} pageUrl={slug} />
+      {!isHomePage && <MobileStickyCta slug={modSlug} />}
     </Layout>
   )
 }


### PR DESCRIPTION
- Updated various links in the PostgreSQL documentation to point to the correct Prisma documentation URLs.
- Added <PostgresCallout /> components to several sections to enhance user guidance and context.